### PR TITLE
Fire stuff

### DIFF
--- a/code/modules/power/roguelighting.dm
+++ b/code/modules/power/roguelighting.dm
@@ -364,7 +364,7 @@
 			if(ash_amount)
 				to_chat(H, span_notice("There seems to be more ash in the [src]."))
 			else
-				to_chat(H, span_notice("You've removed all the ash from the [src]"))
+				to_chat(H, span_notice("I've removed all the ash I can from the [src]."))
 		return 
 	. = ..()
 
@@ -417,7 +417,7 @@
 		if(istype(H))
 			H.visible_message(span_info("[H] warms \his hand over the fire."))
 
-			if(do_after(H, 15, target = src))
+			if(do_after(H, 30, target = src))
 				var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 				to_chat(H, span_warning("HOT!"))
 				if(affecting && affecting.receive_damage( 0, 5 ))		// 5 burn damage

--- a/html/changelogs/doxxmedearly - firestuff.yml
+++ b/html/changelogs/doxxmedearly - firestuff.yml
@@ -1,0 +1,10 @@
+
+author: doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - rscadd: "Campfires, ovens, and hearths that burn long enough now produce ash. This can be removed when the fire is out by clicking it with an empty hand."
+  - rscadd: "Slightly reworded descriptions when examining fires that are not lit with regard to their remaining fuel."
+  - rscadd: "You have a little more time to warm your hands over a brazier before it burns you."


### PR DESCRIPTION
Added a way to retrieve ash that didn't involve burning down random things; you can now take it from a fire or hearth after the fire's been burning long enough.

Ash is used as fertilizer and as a means of creating salt, which is why I thought making it accessible in a sensible way might help folks. Could expand its uses in the future.

Updated the description of fires that are out but still have fuel. Bothered me that it said "the fire will last for x minutes" so now it says "There's enough fuel for a fire to last for x minutes." Small but it was annoying to me.

I like the idea of warming your hands. I did not like that braziers apparently burn them very quickly when you do this. There's a bit more leeway now. 