### PR TITLE
Changes lux to thauma

### DIFF
--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -11,7 +11,7 @@
 	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery_step/extract_lux
-	name = "Extract Lux"
+	name = "Extract Thauma"
 	implements = list(
 		TOOL_SCALPEL = 80,
 	)
@@ -29,22 +29,22 @@
 		return FALSE
 
 /datum/surgery_step/extract_lux/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	display_results(user, target, span_notice("I begin to scrape lux from [target]'s heart..."),
-		span_notice("[user] begins to scrape lux from [target]'s heart."),
-		span_notice("[user] begins to scrape lux from [target]'s heart."))
+	display_results(user, target, span_notice("I begin to scrape thauma from [target]'s heart..."),
+		span_notice("[user] begins to scrape thauma from [target]'s heart."),
+		span_notice("[user] begins to scrape thauma from [target]'s heart."))
 	return TRUE
 
 /datum/surgery_step/extract_lux/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	target.emote("painscream")
 	if(target.has_status_effect(/datum/status_effect/debuff/devitalised))
-		display_results(user, target, span_notice("You cannot draw lux from [target]; they have none left to give."),
-		"[user] extracts lux from [target]'s innards.",
-		"[user] extracts lux from [target]'s innards.")
+		display_results(user, target, span_notice("You cannot draw thauma from [target]; they have none left to give."),
+		"[user] extracts thauma from [target]'s innards.",
+		"[user] extracts thauma from [target]'s innards.")
 		return FALSE
 	else
-		display_results(user, target, span_notice("You extract a single dose of lux from [target]'s heart."),
-			"[user] extracts lux from [target]'s innards.",
-			"[user] extracts lux from [target]'s innards.")
+		display_results(user, target, span_notice("You extract a single dose of thauma from [target]'s heart."),
+			"[user] extracts thauma from [target]'s innards.",
+			"[user] extracts thauma from [target]'s innards.")
 		new /obj/item/reagent_containers/lux(target.loc)
 		target.apply_status_effect(/datum/status_effect/debuff/devitalised)
 	return TRUE

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -11,7 +11,7 @@
 	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery_step/infuse_lux
-	name = "Infuse Lux"
+	name = "Infuse Thauma"
 	implements = list(
 		/obj/item/reagent_containers/lux = 80,
 	)
@@ -30,26 +30,26 @@
 
 /datum/surgery_step/infuse_lux/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	display_results(user, target, span_notice("I begin to revive [target]..."),
-		span_notice("[user] begins to work lux into [target]'s heart."),
-		span_notice("[user] begins to work lux into [target]'s heart."))
+		span_notice("[user] begins to work thauma into [target]'s heart."),
+		span_notice("[user] begins to work thauma into [target]'s heart."))
 	return TRUE
 
 /datum/surgery_step/infuse_lux/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	var/revive_pq = PQ_GAIN_REVIVE
 	if(target.mob_biotypes & MOB_UNDEAD)
 		display_results(user, target, span_notice("You cannot infuse life into the undead! The rot must be cured first."),
-		"[user] works the lux into [target]'s innards.",
-		"[user] works the lux into [target]'s innards.")
+		"[user] works the thauma into [target]'s innards.",
+		"[user] works the thauma into [target]'s innards.")
 		return FALSE
 	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	if(!target.revive(full_heal = FALSE))
-		display_results(user, target, span_notice("The lux refuses to meld with [target]'s heart. Their damage must be too severe still."),
-			"[user] works the lux into [target]'s innards, but nothing happens.",
-			"[user] works the lux into [target]'s innards, but nothing happens.")
+		display_results(user, target, span_notice("The thauma refuses to meld with [target]'s heart. Their damage must be too severe still."),
+			"[user] works the thauma into [target]'s innards, but nothing happens.",
+			"[user] works the thauma into [target]'s innards, but nothing happens.")
 		return FALSE
-	display_results(user, target, span_notice("You succeed in restarting [target]'s heart with the infusion of lux."),
-		"[user] works the lux into [target]'s innards.",
-		"[user] works the lux into [target]'s innards.")
+	display_results(user, target, span_notice("You succeed in restarting [target]'s heart with the infusion of thauma."),
+		"[user] works the thauma into [target]'s innards.",
+		"[user] works the thauma into [target]'s innards.")
 	var/mob/living/carbon/spirit/underworld_spirit = target.get_spirit()
 	if(underworld_spirit)
 		var/mob/dead/observer/ghost = underworld_spirit.ghostize()
@@ -70,5 +70,5 @@
 /datum/surgery_step/infuse_lux/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)
 	display_results(user, target, span_warning("I screwed up!"),
 		span_warning("[user] screws up!"),
-		span_notice("[user] works the lux into [target]'s innards."), TRUE)
+		span_notice("[user] works the thauma into [target]'s innards."), TRUE)
 	return TRUE

--- a/html/changelogs/hocka-thaumapr.yml
+++ b/html/changelogs/hocka-thaumapr.yml
@@ -1,0 +1,8 @@
+
+author: "hocka"
+
+delete-after: True
+
+changes:
+  - rscadd: "Reworded 'lux' to 'thauma' in the transfusion surgery text prompts."
+  - rscadd: "Changed the name of the 'lux' item to 'thauma'."

--- a/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
+++ b/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
@@ -1,5 +1,5 @@
 /obj/item/reagent_containers/lux
-	name = "lux"
+	name = "thauma"
 	desc = "The stuff of life and souls, retrieved from within a hopefully-willing donor. It's a bit clammy and squishy, like a half-fried egg."
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "lux"


### PR DESCRIPTION
As title says, changing mentions of 'lux' to say 'thauma' instead, including the item name itself, to bring it more in-line with Encore's lore.
