### PR TITLE
Better Bait

### DIFF
--- a/code/game/objects/items/rogueitems/bait.dm
+++ b/code/game/objects/items/rogueitems/bait.dm
@@ -50,7 +50,7 @@
 		if(world.time > check_counter + 10 SECONDS)
 			check_counter = world.time
 			var/area/A = get_area(src)
-			if(A.outdoors)
+			if(A.outdoors && !istype(A, /area/rogue/outdoors/town))
 				var/list/possible_targets = list()
 				for(var/obj/item/bait/B in range(7, src))
 					if(B == src)
@@ -61,6 +61,9 @@
 					return
 				possible_targets = list()
 				for(var/obj/structure/flora/roguetree/RT in range(7, src))
+					if(can_see(src, RT, 7))
+						possible_targets += RT
+				for(var/obj/structure/flora/newtree/RT in range(7, src))
 					if(can_see(src, RT, 7))
 						possible_targets += RT
 				for(var/obj/structure/flora/roguegrass/bush/RT in range(7, src))

--- a/code/game/objects/items/rogueitems/bait.dm
+++ b/code/game/objects/items/rogueitems/bait.dm
@@ -60,9 +60,6 @@
 				if(possible_targets.len)
 					return
 				possible_targets = list()
-				for(var/obj/structure/flora/roguetree/RT in range(7, src))
-					if(can_see(src, RT, 7))
-						possible_targets += RT
 				for(var/obj/structure/flora/newtree/RT in range(7, src))
 					if(can_see(src, RT, 7))
 						possible_targets += RT

--- a/html/changelogs/hocka-betterbait.yml
+++ b/html/changelogs/hocka-betterbait.yml
@@ -1,0 +1,7 @@
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - rscadd: "Allows bait to trigger animal spawns off of regular trees as well as the static, creepy-faced one."
+  - rscadd: "Added an additional check to make sure bait cannot be used inside the town of Doma itself."

--- a/html/changelogs/hocka-betterbait.yml
+++ b/html/changelogs/hocka-betterbait.yml
@@ -3,5 +3,5 @@ author: "Hocka"
 delete-after: True
 
 changes:
-  - rscadd: "Allows bait to trigger animal spawns off of regular trees as well as the static, creepy-faced one."
+  - rscadd: "Allows bait to trigger animal spawns off of regular trees instead of the weird ones with faces."
   - rscadd: "Added an additional check to make sure bait cannot be used inside the town of Doma itself."


### PR DESCRIPTION
Makes bait more reliable and less obtuse to use by letting it cause animal spawns off of the far more common tree type, while removing the old one from the list - namely because that type of tree is very uncommon and is typically surrounded by regular trees anyway.

Also put an additional condition on the area check to ensure it won't cause animal spawns in the town of Doma itself.