### PR TITLE
Stockpile machine accepts fish

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -306,3 +306,14 @@
 	export_price = 3
 	importexport_amt = 10
 	passive_generation = 2
+
+/datum/roguestock/stockpile/fish
+	name = "Fish"
+	desc = "Edible creature of the sea."
+	item_type = /obj/item/reagent_containers/food/snacks/fish
+	payout_price = 3
+	withdraw_price = 5
+	transport_fee = 2
+	export_price = 8
+	importexport_amt = 5
+	passive_generation = 1

--- a/html/changelogs/doxxmedearly - stockpile.yml
+++ b/html/changelogs/doxxmedearly - stockpile.yml
@@ -1,0 +1,7 @@
+author: doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - rscadd: "Automated stockpiler now accepts fish as a bounty."


### PR DESCRIPTION
It accepted other kinds of meat. Now it accepts fish into the stockpile, though at a lower cost/payout than the other meats. 