### PR TITLE
Ranger-Zealot, Scout-Templar & Ranger-Knight

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -56,6 +56,10 @@
 	icon_state = "blackbelt"
 	sellprice = 10
 
+/obj/item/storage/belt/rogue/leather/black/puritan/Initialize()
+	. = ..()
+	contents = list(new /obj/item/storage/keyring/puritan)			// not doing the same checks as the coin spawn pouches because this belt shouldn't be full on spawning, maybe change if it becomes a problem though ~ Hocka
+
 /obj/item/storage/belt/rogue/leather/plaquesilver
 	name = "plaque belt"
 	icon_state = "silverplaque"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -10,7 +10,7 @@
 /datum/outfit/job/roguetown/adventurer/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	var/classes = list("Ranger","Gloom Stalker", "Ranger-Knight") // Ranger Knight is the unique subclass. Gives you steel breastplate and a sword.
+	var/classes = list("Ranger","Gloom Stalker", "Ranger-Knight")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -114,7 +114,7 @@
 			beltl = /obj/item/rogueweapon/sword/short
 			pants = /obj/item/clothing/under/roguetown/chainlegs
 			head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -10,7 +10,7 @@
 /datum/outfit/job/roguetown/adventurer/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	var/classes = list("Ranger","Gloom Stalker",) // Ranger Knight is the unique subclass. Gives you steel breastplate and a sword.
+	var/classes = list("Ranger","Gloom Stalker", "Ranger-Knight") // Ranger Knight is the unique subclass. Gives you steel breastplate and a sword.
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)
@@ -20,6 +20,7 @@
 			to_chat(H, span_warning("Rangers are masters of nature, often hired as pathfinders, bodyguards and mercenaries in areas of wilderness untraversable to common soldiery."))
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+			pants = /obj/item/clothing/under/roguetown/trou/leather
 			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 			gloves = /obj/item/clothing/gloves/roguetown/leather
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
@@ -64,6 +65,7 @@
 			to_chat(H, span_warning("Rangers are masters of nature, often hired as pathfinders, bodyguards and mercenaries in areas of wilderness untraversable to common soldiery."))
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+			pants = /obj/item/clothing/under/roguetown/trou/leather
 			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 			gloves = /obj/item/clothing/gloves/roguetown/leather
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
@@ -98,12 +100,52 @@
 			H.change_stat("perception", 2)
 			H.change_stat("endurance", 1)
 			H.change_stat("speed", 3)
-		
-	if(H.pronouns == HE_HIM || H.pronouns == THEY_THEM || H.pronouns == IT_ITS)
-		pants = /obj/item/clothing/under/roguetown/trou/leather
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-	else
-		pants = /obj/item/clothing/under/roguetown/tights/black
+		if("Ranger-Knight")
+			to_chat(H, span_warning("Ranger-Knights are the select few who have elected to diversify their skills with medium armor, melee weaponry and ranged warfare - at the cost of being lesser than dedicated followers of those arts."))
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			gloves = /obj/item/clothing/gloves/roguetown/chain
+			wrists = /obj/item/clothing/wrists/roguetown/bracers
+			belt = /obj/item/storage/belt/rogue/leather
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/half
+			cloak = /obj/item/clothing/cloak/tabard
+			beltr = /obj/item/flashlight/flare/torch/lantern
+			beltl = /obj/item/rogueweapon/sword/short
+			pants = /obj/item/clothing/under/roguetown/chainlegs
+			head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+			H.change_stat("strength", 2)
+			H.change_stat("constitution", 2)
+			H.change_stat("endurance", 3)
+
+			var/weapons = list("Recurve Bow","Longbow", "Crossbow")
+			var/weaponchoice = input(H, "Choose your weapon", "TAKE UP ARMS") as anything in weapons
+			H.set_blindness(0)
+			switch(weaponchoice)
+				if("Recurve Bow")
+					H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve(H), TRUE)
+					H.put_in_hands(new /obj/item/quiver/arrows(H), TRUE)
+					H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+				if("Longbow")
+					H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve(H), TRUE)
+					H.put_in_hands(new /obj/item/quiver/arrows(H), TRUE)
+					H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+				if("Crossbow")
+					H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow(H), TRUE)
+					H.put_in_hands(new /obj/item/quiver/bolts(H), TRUE)
+					H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
 
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -214,7 +214,7 @@
 	beltl = /obj/item/rogueweapon/sword/short
 
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
@@ -297,7 +297,7 @@
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1)
 
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
@@ -310,7 +310,6 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
 		H.change_stat("perception", 2)
 		H.change_stat("speed", 2)
 		H.change_stat("endurance", 2)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -23,8 +23,6 @@
 	has_loadout = TRUE
 	allowed_patrons = ALL_PALADIN_PATRONS
 	belt = /obj/item/storage/belt/rogue/leather/black
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
-	beltr = /obj/item/storage/keyring/puritan
 	id = /obj/item/clothing/ring/silver
 	backl = /obj/item/storage/backpack/rogue/satchel
 	
@@ -63,6 +61,8 @@
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	wrists = /obj/item/clothing/wrists/roguetown/wrappings
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltr = /obj/item/storage/keyring/puritan
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE) 
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
@@ -126,6 +126,8 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltr = /obj/item/storage/keyring/puritan
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
@@ -167,3 +169,84 @@
 			H.put_in_hands(new /obj/item/rogueweapon/mace(H), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
 
+/datum/advclass/templar/heavyranger
+	name = "Ranger-Zealot"
+	tutorial = "You are a marksman of the Church, trained in heavy equipment and zealous warfare. What you lack in swordsmanship you make up for with delivering your God's will from afar, your faith guiding your shots true."
+	outfit = /datum/outfit/job/roguetown/templar/heavyranger
+	
+	category_tags = list(CTAG_TEMPLAR)
+
+/datum/outfit/job/roguetown/templar/heavyranger/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
+	wrists = /obj/item/clothing/neck/roguetown/psicross/gani
+	cloak = /obj/item/clothing/cloak/tabard/crusader/tief
+	switch(H.patron?.type)
+		if(/datum/patron/elemental/visires)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/visires
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/visires
+			cloak = /obj/item/clothing/cloak/templar/visires
+		if(/datum/patron/elemental/gani)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/gani
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/ganihelm
+			cloak = /obj/item/clothing/cloak/tabard/crusader/gani
+		if(/datum/patron/elemental/mjallidhorn)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/mjallidhorn
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/mjallidhorn
+			cloak = /obj/item/clothing/cloak/templar/mjallidhorn
+		if(/datum/patron/elemental/akan)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/akan
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/akan
+			cloak = /obj/item/clothing/cloak/tabard/crusader/akan
+		if(/datum/patron/all_aspect)
+			wrists = /obj/item/clothing/neck/roguetown/psicross
+			cloak = /obj/item/clothing/cloak/tabard/crusader/all_aspect
+	gloves = /obj/item/clothing/gloves/roguetown/chain
+	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	pants = /obj/item/clothing/under/roguetown/chainlegs
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	beltr = /obj/item/flashlight/flare/torch/lantern
+	beltl = /obj/item/rogueweapon/sword/short
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/mid = 1, /obj/item/storage/keyring/puritan = 1)
+
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+		H.change_stat("strength", 2)
+		H.change_stat("constitution", 2)
+		H.change_stat("endurance", 3)
+		
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	
+	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_spells_templar(H)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+
+/datum/outfit/job/roguetown/templar/heavyranger/choose_loadout(mob/living/carbon/human/H)
+	. = ..()
+	var/weapons = list("Crossbow", "Longbow")
+	var/weapon_choice = input(H,"Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+	switch(weapon_choice)
+		if("Crossbow")
+			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow(H), TRUE)
+			H.put_in_hands(new /obj/item/quiver/bolts(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+		if("Longbow")
+			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow(H), TRUE)
+			H.put_in_hands(new /obj/item/quiver/arrows(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -12,8 +12,8 @@
 	min_pq = -999
 	max_pq = null
 	round_contrib_points = 2
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 99//Uncapped basically
+	spawn_positions = 99
 	advclass_cat_rolls = list(CTAG_TEMPLAR = 20)
 	display_order = JDO_TEMPLAR
 	
@@ -214,7 +214,7 @@
 	beltl = /obj/item/rogueweapon/sword/short
 
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
@@ -252,3 +252,87 @@
 			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow(H), TRUE)
 			H.put_in_hands(new /obj/item/quiver/arrows(H), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+
+/datum/advclass/templar/lightranger
+	name = "Scout-Templar"
+	tutorial = "You are a scout and tracker of the church. While not as skilled with heavier equipment as your paladin brethren, you wield your faith well-enough all the same."
+	outfit = /datum/outfit/job/roguetown/templar/lightranger
+	
+	category_tags = list(CTAG_TEMPLAR)
+
+/datum/outfit/job/roguetown/templar/lightranger/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
+	wrists = /obj/item/clothing/neck/roguetown/psicross/gani
+	cloak = /obj/item/clothing/cloak/tabard/crusader/tief
+	switch(H.patron?.type)
+		if(/datum/patron/elemental/visires)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/visires
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/visires
+			cloak = /obj/item/clothing/cloak/templar/visires
+		if(/datum/patron/elemental/gani)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/gani
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/ganihelm
+			cloak = /obj/item/clothing/cloak/tabard/crusader/gani
+		if(/datum/patron/elemental/mjallidhorn)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/mjallidhorn
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/mjallidhorn
+			cloak = /obj/item/clothing/cloak/templar/mjallidhorn
+		if(/datum/patron/elemental/akan)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/akan
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/akan
+			cloak = /obj/item/clothing/cloak/tabard/crusader/akan
+		if(/datum/patron/all_aspect)
+			wrists = /obj/item/clothing/neck/roguetown/psicross
+			cloak = /obj/item/clothing/cloak/tabard/crusader/all_aspect
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
+	pants= /obj/item/clothing/under/roguetown/trou/leather
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+	belt = /obj/item/storage/belt/rogue/leather/black/puritan
+	beltl = /obj/item/flashlight/flare/torch/lantern
+	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1)
+
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+		H.change_stat("perception", 2)
+		H.change_stat("speed", 2)
+		H.change_stat("endurance", 2)
+		
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	
+	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_spells_templar(H)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+
+/datum/outfit/job/roguetown/templar/lightranger/choose_loadout(mob/living/carbon/human/H)
+	. = ..()
+	var/weapons = list("Crossbow", "Recurve Bow")
+	var/weapon_choice = input(H,"Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+	switch(weapon_choice)
+		if("Crossbow")
+			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow(H), TRUE)
+			H.put_in_hands(new /obj/item/quiver/bolts(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		if("Recurve Bow")
+			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve(H), TRUE)
+			H.put_in_hands(new /obj/item/quiver/arrows(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -22,7 +22,6 @@
 /datum/outfit/job/roguetown/templar
 	has_loadout = TRUE
 	allowed_patrons = ALL_PALADIN_PATRONS
-	belt = /obj/item/storage/belt/rogue/leather/black
 	id = /obj/item/clothing/ring/silver
 	backl = /obj/item/storage/backpack/rogue/satchel
 	
@@ -61,6 +60,7 @@
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	wrists = /obj/item/clothing/wrists/roguetown/wrappings
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
+	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/storage/keyring/puritan
 	if(H.mind)
@@ -126,6 +126,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/storage/keyring/puritan
 	if(H.mind)
@@ -202,14 +203,15 @@
 			wrists = /obj/item/clothing/neck/roguetown/psicross
 			cloak = /obj/item/clothing/cloak/tabard/crusader/all_aspect
 	gloves = /obj/item/clothing/gloves/roguetown/chain
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	belt = /obj/item/storage/belt/rogue/leather/black/puritan
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	beltl = /obj/item/rogueweapon/sword/short
-	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/mid = 1, /obj/item/storage/keyring/puritan = 1)
+	backpack_contents = list(/obj/item/storage/keyring/puritan = 1)
 
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -23,7 +23,6 @@
 	has_loadout = TRUE
 	allowed_patrons = ALL_PALADIN_PATRONS
 	id = /obj/item/clothing/ring/silver
-	backl = /obj/item/storage/backpack/rogue/satchel
 	
 /datum/job/roguetown/templar/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -57,6 +56,7 @@
 		if(/datum/patron/elemental/akan)
 			neck = /obj/item/clothing/neck/roguetown/psicross/akan
 			cloak = /obj/item/clothing/cloak/tabard/crusader/akan
+	backl = /obj/item/storage/backpack/rogue/satchel
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	wrists = /obj/item/clothing/wrists/roguetown/wrappings
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
@@ -120,6 +120,7 @@
 			wrists = /obj/item/clothing/neck/roguetown/psicross
 			cloak = /obj/item/clothing/cloak/tabard/crusader/all_aspect
 	backr = /obj/item/rogueweapon/shield/tower/metal
+	backl = /obj/item/storage/backpack/rogue/satchel
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	pants = /obj/item/clothing/under/roguetown/chainlegs
@@ -211,7 +212,6 @@
 	belt = /obj/item/storage/belt/rogue/leather/black/puritan
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	beltl = /obj/item/rogueweapon/sword/short
-	backpack_contents = list(/obj/item/storage/keyring/puritan = 1)
 
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/html/changelogs/hocka-rangerknight.yml
+++ b/html/changelogs/hocka-rangerknight.yml
@@ -1,0 +1,9 @@
+author: "hocka"
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the Ranger-Zealot and Scout-Templar subclasses to Templar, a heavier unit with access to a steel shortsword and a longbow/crossbow and a lighter unit that foregoes a sword at all respectively, in exchange for more muted skills and less carrying capacity."
+  - rscadd: "Added a subtype of the black leather belts to allow Scout-Templars and Ranger-Zealots to spawn with the church keyring in their belt, on account of their drastically lowered free inventory spots."
+  - rscadd: "Added the Ranger-Knight subclass to Ranger (adventurer), essentially a copy of the Ranger-Zealot but without access to Miracles and is able to choose between a Recurve, Longbow or Crossbow."
+  - rscadd: "Shuffled around the vars for determining the pants that are equipped on all subclasses of Ranger (adventurer), mostly for the benefit of the Ranger-Knight's slightly heavy armour set."


### PR DESCRIPTION
Adds the Ranger-Zealot and Scout-Templar subclasses to Templar.

Ranger-Zealot starts with the usual Templar stuff (keying, coins, religious amulet as well as mostly similar armour to the Templar, but instead of choosing melee weapon they simply spawn with a steel shortsword on their hip (and don't spawn with a chain coif anymore.) Instead they choose between a Crossbow or Longbow (with accompanying bolts/arrows.) They also spawn with a lamptern, seeing as the Ranger and Gloomstalker subclasses both start with one (likely because one-handing is simply not an option with a bow.)

Ranger-Zealot gets the following skills & stats:
Swords - Journeyman
Maces - Apprentice
Whips/Flails - Apprentice
Crossbows - Apprentice (Journeyman if they select the Crossbow at spawn)
Bows - Apprentice (Ditto but for Longbow)
Wrestling - Apprentice
Unarmed - Journeyman
Climbing - Novice
Athletics - Journeyman
Reading - Master
Miracles - Apprentice
Medicine - Novice
Shields - Novice

+2 Strength
+2 Constitution
+3 Endurance

Plate Training

Esentially they're just nerfed templars with the same statblock that get to choose between a crossbow or longbow.


Scout-Templar is more similar to getting Gloom Stalker and pushing it into the Templar role, and flavouring it as more of an advance or reconnaissance unit. They don't get chain armour, instead just some studded leather for their chest and not much else. Keeping with the theme of being a lighter unit than the Ranger-Zealot, they choose between a Recurve Bow and Crossbow, instead of a Longbow. They also don't spawn with a shortsword, instead spawning with a hunting knife in their backpack, so they can actually have a bag on them.

Scout-Templar gets the following skills & stats:
Knives - Apprentice
Maces - Apprentice
Whips/Flails - Apprentice
Crossbows - Apprentice (Expert if they pick Crossbow when they spawn in)
Bows - Apprentice (Same again)
Wrestling - Apprentice
Unarmed - Apprentice
Climbing - Journeyman
Sneaking - Journeyman
Athletics - Journeyman
Reading - Master
Miracles - Apprentice
Medicine - Novice

+2 Perception
+2 Speed
+2 Endurance

Dodge Expert

Like I said, an attempt at marrying Gloom Stalker with Templar.


Ranger-Knight is more akin to Templar in its starting loadout, with a few extra boons granted on account of not having access to miracles. They start with a chainmail shirt, iron cuirass, chain gauntlets, chain leggings & visored sallet. Then they get the typical personal tabard that they can customize. The Ranger-Knight is also free to choose between the Crossbow, Recurve Bow or Longbow. Like the Ranger-Zealot, they also start with a steel shortsword on their hip - this massively lowers carrying capacity, because you basically have nowhere for a satchel or backpack to go.

Ranger-Knight gets the following skills & stats:

Swords - Journeyman
Maces - Apprentice
Whips/Flails - Apprentice
Crossbows - Apprentice (Journeyman if picked on spawn)
Bows - Apprentice (Once again, same here)
Wrestling - Apprentice
Unarmed - Journeyman
Climbing - Novice
Athletics - Journeyman
Medicine - Novice
Shields - Novice

+2 Strength
+2 Constitution
+3 Endurance

Maille Training
Dodge Expert



Frankly, I have no idea just how much skills affect combat and whatnot in this game, or if one piece of armour might actually be hilariously unassumingly overpowered. I'll be insanely surprised if these subclasses aren't broken/underpowered/boring/awful as hell to play in some way or another or in some incredibly specific circumstances. Feedback is appreciated on this.