### PR TITLE
Oat substitute for crafting normal bait

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -539,10 +539,17 @@
 
 
 /datum/crafting_recipe/roguetown/bait
-	name = "bait"
+	name = "bait (wheat)"
 	result = /obj/item/bait
 	reqs = list(/obj/item/storage/roguebag = 1,
 				/obj/item/reagent_containers/food/snacks/grown/wheat = 2)
+	subtype_reqs = TRUE
+
+/datum/crafting_recipe/roguetown/oat_bait
+	name = "bait (oat)"
+	result = /obj/item/bait
+	reqs = list(/obj/item/storage/roguebag = 1,
+				/obj/item/reagent_containers/food/snacks/grown/oat = 2)
 	subtype_reqs = TRUE
 
 /datum/crafting_recipe/roguetown/sbaita

--- a/html/changelogs/hocka-oatbait.yml
+++ b/html/changelogs/hocka-oatbait.yml
@@ -1,0 +1,7 @@
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - rscadd: "Regular bait can now also be made from two sets of oat grains."
+  - rscadd: "Renamed the original bait recipe to 'bait (wheat)'"


### PR DESCRIPTION
Adds a second recipe for crafting regular bait that allows the use of oats instead of wheat grains (similar to how sweet bait uses berries or apples.) Just like the apple/berry sweetbait, they have separate names to distinguish from each other.