### PR TITLE
Produce Supplies Increase

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -39,6 +39,8 @@
 	layer = 2.8;
 	pixel_x = 8
 	},
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town/roofs)
 "abn" = (
@@ -1036,11 +1038,6 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/under/town/basement/keep)
 "aZa" = (
-/obj/structure/closet/crate/chest{
-	base_icon_state = "woodchestalt";
-	icon_state = "woodchestalt";
-	name = "meat chest"
-	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/egg,
@@ -1054,6 +1051,9 @@
 /obj/structure/fluff/railing/border{
 	dir = 1;
 	icon_state = "border"
+	},
+/obj/structure/closet/crate/chest/crate{
+	name = "meat crate"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
@@ -1195,6 +1195,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"bhb" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "bhq" = (
 /obj/structure/flora/roguegrass/water,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -2026,17 +2030,24 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
 "cfK" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/obj/item/flint,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
 /obj/machinery/light/rogue/torchholder/c,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
+/obj/structure/closet/crate/chest/crate{
+	name = "fruit crate"
+	},
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/apple,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "cgc" = (
@@ -2855,6 +2866,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"cWb" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/obj/effect/decal/mossy,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "cWF" = (
 /obj/item/bedsheet/rogue/fabric,
 /obj/effect/landmark/start/wapprentice{
@@ -3790,6 +3809,10 @@
 /obj/item/needle,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/physician)
+"dYQ" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "dZc" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -4408,7 +4431,21 @@
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/beach)
 "eCg" = (
-/obj/structure/fermenting_barrel/water,
+/obj/structure/closet/crate/chest/crate{
+	name = "grain crate"
+	},
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "eCZ" = (
@@ -4812,6 +4849,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"fcs" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/cow,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "fcx" = (
 /obj/effect/landmark/start/knavewench{
 	dir = 4
@@ -5934,6 +5975,10 @@
 "glZ" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
+"gmg" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "gmr" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
@@ -6371,6 +6416,9 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"gNp" = (
+/turf/open/floor/rogue/hay,
+/area/rogue/outdoors/exposed/town/keep)
 "gNx" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/cloak/half,
@@ -6407,12 +6455,22 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/closet/crate/chest,
+/obj/structure/closet/crate/roguecloset,
 /obj/item/soap,
 /obj/item/soap,
 /obj/item/soap,
 /obj/item/soap,
 /obj/item/soap,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/flint,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "gPs" = (
@@ -7489,7 +7547,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet)
 "hYW" = (
-/obj/structure/closet/crate/chest/crate,
+/obj/structure/closet/crate/chest/crate{
+	name = "surplus crate"
+	},
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
 "hZD" = (
@@ -7871,9 +7936,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "ivK" = (
-/obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
 /obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/basement)
 "iwV" = (
@@ -8284,13 +8353,29 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
 "iRx" = (
-/obj/structure/closet/crate/chest,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup/silver,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -8430,6 +8515,16 @@
 "jbj" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
+/obj/item/reagent_containers/powder/flour,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/town/roofs)
 "jbm" = (
@@ -8966,6 +9061,20 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/town/dwarf)
+"jEY" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/obj/effect/decal/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "jFj" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -9291,6 +9400,12 @@
 /obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
+"jSL" = (
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "jTp" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -9392,7 +9507,7 @@
 "kbK" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/flora/roguegrass/bush/wall,
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
 "kco" = (
 /obj/structure/fluff/railing/border,
@@ -9824,6 +9939,15 @@
 	},
 /turf/open/floor/rogue/sand,
 /area/rogue/outdoors/town)
+"kwP" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/effect/decal/mossy,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "kxB" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -10269,12 +10393,21 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/shelter/town)
 "kXD" = (
-/obj/structure/closet/crate/chest{
-	base_icon_state = "woodchestalt";
-	icon_state = "woodchestalt"
+/obj/structure/closet/crate/chest/crate{
+	name = "grain crate"
 	},
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/tavern)
 "kYd" = (
@@ -10510,26 +10643,20 @@
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/garrison)
 "llP" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup,
-/obj/item/reagent_containers/glass/cup/silver,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/natural/bundle/stick{
+	amount = 10
+	},
+/obj/item/natural/bundle/stick{
+	amount = 10
+	},
+/obj/item/natural/bundle/stick{
+	amount = 10
+	},
+/obj/item/natural/bundle/stick{
+	amount = 10
+	},
+/obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -10608,7 +10735,13 @@
 	dir = 8;
 	pixel_x = -10
 	},
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/obj/effect/decal/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
 "lph" = (
 /obj/structure/closet/crate/drawer,
@@ -10838,6 +10971,9 @@
 /obj/item/reagent_containers/powder/salt,
 /obj/structure/closet/crate/chest/neu,
 /obj/structure/roguemachine/withdraw,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "lDP" = (
@@ -11262,6 +11398,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
+"mbh" = (
+/obj/structure/composter/halffull,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "mbw" = (
 /obj/structure/mineral_door/wood{
 	name = "Town Quarrying Stockroom"
@@ -11627,6 +11767,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"mty" = (
+/obj/effect/decal/mossy,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "mtE" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
@@ -11949,7 +12093,12 @@
 	pixel_y = 0
 	},
 /obj/item/storage/roguebag,
-/obj/item/rogueweapon/hoe,
+/obj/item/rogueweapon/hoe{
+	pixel_x = 4
+	},
+/obj/item/rogueweapon/hoe{
+	pixel_x = -4
+	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "mKF" = (
@@ -12483,17 +12632,21 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cavewet)
 "nnU" = (
-/obj/structure/closet/crate/chest,
+/obj/structure/closet/crate/chest/crate{
+	name = "meat crate"
+	},
 /obj/item/reagent_containers/food/snacks/egg,
 /obj/item/reagent_containers/food/snacks/egg,
 /obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
+/obj/item/reagent_containers/food/snacks/butter,
+/obj/item/reagent_containers/food/snacks/butter,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "noB" = (
@@ -12590,22 +12743,22 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "nry" = (
-/obj/structure/closet/crate/chest,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/butter,
 /obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/closet/crate/chest/crate{
+	name = "produce crate"
+	},
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "nrS" = (
@@ -13495,6 +13648,12 @@
 /area/rogue/outdoors/exposed/town/keep)
 "okQ" = (
 /obj/structure/closet/crate/chest/wicker,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/town)
 "olg" = (
@@ -13662,15 +13821,12 @@
 /area/rogue/indoors/town/tavern)
 "osV" = (
 /obj/structure/closet/crate/roguecloset/dark,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/item/flashlight/flare/torch/metal,
 /obj/item/flashlight/flare/torch/metal,
-/obj/item/reagent_containers/food/snacks/butter,
 /obj/item/candle/yellow,
 /obj/item/candle/yellow,
 /obj/item/candle/yellow,
@@ -14602,6 +14758,13 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/cave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet)
+"ptV" = (
+/obj/structure/fluff/railing/fence{
+	dir = 4;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "ptX" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -14772,7 +14935,13 @@
 	dir = 4;
 	pixel_x = 8
 	},
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/mossy{
+	dir = 8
+	},
+/obj/effect/decal/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
 "pDW" = (
 /obj/structure/fluff/railing/wood{
@@ -16289,6 +16458,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"rjr" = (
+/obj/structure/closet/crate/chest/wicker,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/shelter/town)
 "rjW" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/red,
@@ -16436,22 +16615,24 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "rxn" = (
-/obj/structure/closet/crate/chest{
-	base_icon_state = "woodchestalt";
-	icon_state = "woodchestalt"
-	},
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
+/obj/structure/closet/crate/chest/crate{
+	name = "produce crate"
+	},
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/tavern)
 "rxo" = (
@@ -16686,6 +16867,13 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
+"rIr" = (
+/obj/structure/fluff/railing/fence{
+	dir = 4;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "rIE" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
@@ -17300,6 +17488,12 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/magician)
+"stQ" = (
+/obj/effect/decal/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "sug" = (
 /obj/structure/bars/shop,
 /turf/open/floor/rogue/naturalstone,
@@ -17645,6 +17839,10 @@
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/basement)
 "sGE" = (
@@ -17740,14 +17938,7 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor)
 "sNz" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/natural/bundle/stick,
-/obj/item/natural/bundle/stick,
-/obj/item/natural/bundle/stick,
-/obj/item/natural/bundle/stick,
+/obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -17914,6 +18105,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"sVH" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/hay,
+/area/rogue/outdoors/exposed/town/keep)
 "sVV" = (
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach)
@@ -18381,15 +18576,24 @@
 	pixel_y = 0
 	},
 /obj/structure/rack/rogue/shelf,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
 /obj/item/natural/bundle/stick{
-	pixel_y = 37
+	pixel_y = 37;
+	amount = 10;
+	pixel_x = 10
 	},
 /obj/item/natural/bundle/stick{
-	pixel_y = 37
+	pixel_y = 37;
+	amount = 10;
+	pixel_x = 6
 	},
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
+/obj/item/natural/bundle/stick{
+	pixel_y = 37;
+	amount = 10;
+	pixel_x = 2
+	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/tavern)
 "tuH" = (
@@ -18758,7 +18962,6 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cavewet)
 "tLn" = (
-/obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/cheese,
 /obj/item/reagent_containers/food/snacks/rogue/cheese,
 /obj/item/reagent_containers/food/snacks/rogue/cheese,
@@ -18776,6 +18979,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-w"
 	},
+/obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "tLM" = (
@@ -18865,10 +19069,7 @@
 /obj/item/seeds/onion,
 /obj/item/seeds/onion,
 /obj/structure/closet/crate/chest/wicker,
-/obj/item/seeds/onion,
-/obj/item/seeds/onion,
-/obj/item/seeds/onion,
-/obj/item/seeds/onion,
+/obj/item/seeds/apple,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/basement)
 "tQT" = (
@@ -20447,6 +20648,12 @@
 	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/physician)
+"vDx" = (
+/obj/effect/decal/mossy{
+	dir = 1
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "vDy" = (
 /obj/item/roguemachine/merchant,
 /turf/open/floor/rogue/concrete,
@@ -20626,6 +20833,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"vQR" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/chicken,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "vQX" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
@@ -20763,6 +20974,12 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"vYa" = (
+/obj/effect/decal/mossy{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "vYb" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -20842,6 +21059,18 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/town/basement/keep)
+"wfq" = (
+/obj/structure/rack/rogue/shelf/big{
+	icon_state = "shelf_biggest";
+	pixel_y = 0
+	},
+/obj/item/storage/roguebag,
+/obj/item/rogueweapon/thresher{
+	pixel_x = -6
+	},
+/obj/item/rogueweapon/hoe,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/exposed/town/keep)
 "wfu" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
@@ -51076,7 +51305,7 @@ kou
 drC
 xzO
 eXe
-okQ
+rjr
 fCf
 aXu
 eXe
@@ -53647,7 +53876,7 @@ fQk
 dbE
 hks
 dbE
-dbE
+vQR
 clF
 qQJ
 qQJ
@@ -54160,7 +54389,7 @@ fQk
 fQk
 fuU
 haR
-fGa
+gmg
 vQX
 iNI
 bwj
@@ -182872,9 +183101,9 @@ aff
 vfd
 uDk
 aff
-bIj
-sva
-sva
+dYQ
+fcs
+gNp
 jOs
 cFy
 uLX
@@ -183129,9 +183358,9 @@ bIj
 aff
 aff
 aff
+bhb
 bIj
-bIj
-sva
+sVH
 jOs
 kdx
 kVU
@@ -183382,13 +183611,13 @@ cDv
 nIU
 aff
 sva
-bIj
+mbh
 wAt
 aff
 aff
-bIj
-bIj
-sva
+dYQ
+ptV
+rIr
 jOs
 cFy
 uLX
@@ -183645,7 +183874,7 @@ aff
 aff
 bIj
 bIj
-sva
+wfq
 jOs
 kdx
 kVU
@@ -184156,9 +184385,9 @@ ooI
 sRY
 fFI
 aff
-bIj
-bIj
-bIj
+vYa
+vYa
+vYa
 bIj
 jOs
 kdx
@@ -184412,11 +184641,11 @@ jaB
 rqA
 haJ
 jkg
-aff
+mty
 pDI
-bIj
-wAt
-bIj
+jSL
+cWb
+vDx
 jOs
 kdx
 jOs
@@ -185440,7 +185669,7 @@ jkg
 jkg
 jkg
 jkg
-aff
+mty
 loJ
 jOs
 aEW
@@ -185697,8 +185926,8 @@ aff
 aff
 mTw
 aff
-aff
-bIj
+mty
+stQ
 jOs
 mhO
 sHx
@@ -185954,8 +186183,8 @@ bIj
 umO
 umO
 umO
-umO
-umO
+kwP
+jEY
 jOs
 qZh
 wyA

--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -121,13 +121,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs/keep)
-"afp" = (
-/obj/structure/handcart{
-	dir = 8
-	},
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/town/basement)
 "agA" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -9894,6 +9887,7 @@
 /area/rogue/indoors/town/magician)
 "kvf" = (
 /obj/structure/plough,
+/obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/basement)
 "kvA" = (
@@ -54124,7 +54118,7 @@ ylR
 cGF
 fvL
 fQk
-afp
+jyd
 kvf
 ocB
 pBC

--- a/html/changelogs/furrycactus - garden maxing.yml
+++ b/html/changelogs/furrycactus - garden maxing.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Increases the amount of produce around town. The Inn backroom starts stocked a little better, especially with more grain. The Keep has received a similar buff, with a slight edge over the commonfolk in the form of a fruit crate in the basement with apples and jacksberries. The windmill also has grain and flour in it."
+  - rscadd: "Adds a small cow and chicken pen to the Keep, plus some farming supplies for a tiny garden. No seeds though."
+  - rscadd: "Adds two chickens to the public cow pen."


### PR DESCRIPTION
We are starving out here.

  - rscadd: "Increases the amount of produce around town. The Inn backroom starts stocked a little better, especially with more grain. The Keep has received a similar buff, with a slight edge over the commonfolk in the form of a fruit crate in the basement with apples and jacksberries. The windmill also has grain and flour in it."
  - rscadd: "Adds a small cow and chicken pen to the Keep, plus some farming supplies for a tiny garden. No seeds though."
  - rscadd: "Adds two chickens to the public cow pen."