### PR TITLE
Fixes Fishy Funds From Fish

### DIFF
--- a/code/modules/roguetown/roguejobs/fisher/fish.dm
+++ b/code/modules/roguetown/roguejobs/fisher/fish.dm
@@ -70,7 +70,13 @@
 		STOP_PROCESSING(SSobj, src)
 		return 1
 
+/obj/item/reagent_containers/food/snacks/fish/common //Generic fish for stockpiles and such
 
+/obj/item/reagent_containers/food/snacks/fish/common/Initialize() //No variations in rarity, sprite, stockpile, etc. 
+	. = ..()
+	name = "common [initial(name)]"
+	sellprice = initial(sellprice)
+	icon_state = "carpcom"
 
 /obj/item/reagent_containers/food/snacks/fish/carp
 	name = "carp"

--- a/code/modules/roguetown/roguemachine/_withdraw_tab.dm
+++ b/code/modules/roguetown/roguemachine/_withdraw_tab.dm
@@ -66,7 +66,11 @@
 			D.held_items[source_stockpile]--
 			budget -= total_price
 			SStreasury.give_money_treasury(D.withdraw_price, "stockpile withdraw")
-			var/obj/item/I = new D.item_type(parent_structure.loc)
+			var/obj/item/I
+			if(D.withdrawal_type)
+				I = new D.withdrawal_type(parent_structure.loc)
+			else
+				I = new D.item_type(parent_structure.loc)
 			var/mob/user = usr
 			if(!user.put_in_hands(I))
 				I.forceMove(get_turf(user))

--- a/code/modules/roguetown/roguestock/_roguestock.dm
+++ b/code/modules/roguetown/roguestock/_roguestock.dm
@@ -18,6 +18,7 @@
 	var/stable_price = FALSE
 	var/percent_bounty = FALSE
 	var/passive_generation = 0 //How much to generate in the remote section each firing of the treasury system.
+	var/withdrawal_type = null //When set, vomitoriums and stockpiles will dispense this type instead. Use this for items that Initialize() with random values, like fish.
 
 /datum/roguestock/New()
 	..()

--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -311,8 +311,9 @@
 	name = "Fish"
 	desc = "Edible creature of the sea."
 	item_type = /obj/item/reagent_containers/food/snacks/fish
+	withdrawal_type = /obj/item/reagent_containers/food/snacks/fish/common
 	payout_price = 3
-	withdraw_price = 5
+	withdraw_price = 10
 	transport_fee = 2
 	export_price = 8
 	importexport_amt = 5


### PR DESCRIPTION
Fixes #75

Fish price (to buy) increased
Dispensed fish will always be a common, generic fish. 
Any items going forward that Initialize with a random sellvalue can now utilize `withdrawal_type` to set a specific type to dispense, to avoid fuckery.

Huge thanks to Winter for fix suggestions and very detailed feedback on this issue, since I'm unfamiliar with the merchant.