### PR TITLE
Fixes double-up spells

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -170,6 +170,8 @@
 
 	if(spells && H.mind)
 		for(var/S in spells)
+			if(H.mind.has_spell(S))
+				continue
 			H.mind.AddSpell(new S)
 
 	if(H.gender == FEMALE)


### PR DESCRIPTION
Fixes #70 

Spells granted from class + patron should no longer double up.

Caused because the check for duplicate spells was happening too early in the spawn/equip order. Added a duplicate check to the last time spells get added on spawn. 