### PR TITLE
Spell granting adjustments

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -76,7 +76,7 @@
 	if(!prog_amt) // no point in the rest if it's just an expenditure
 		return TRUE
 	progression = clamp(progression + prog_amt, 0, max_progression)
-	var/obj/effect/spell_unlocked
+	var/obj/effect/proc_holder/spell/spell_unlocked
 	switch(level)
 		if(CLERIC_T0)
 			if(progression >= CLERIC_REQ_1)
@@ -96,11 +96,12 @@
 				level = CLERIC_T4
 	if(!spell_unlocked || !holder?.mind || holder.mind.has_spell(spell_unlocked, specific = FALSE))
 		return TRUE
-	spell_unlocked = new spell_unlocked
-	if(!silent)
-		to_chat(holder, span_boldnotice("I have unlocked a new spell: [spell_unlocked]"))
-	usr.mind.AddSpell(spell_unlocked)
-	LAZYADD(granted_spells, spell_unlocked)
+	if(spell_unlocked.devotion_unlockable)
+		spell_unlocked = new spell_unlocked
+		if(!silent)
+			to_chat(holder, span_boldnotice("I have unlocked a new spell: [spell_unlocked]"))
+		usr.mind.AddSpell(spell_unlocked)
+		LAZYADD(granted_spells, spell_unlocked)
 	return TRUE
 
 /datum/devotion/proc/grant_spells(mob/living/carbon/human/H)
@@ -108,6 +109,9 @@
 		return
 
 	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1)
+	if(length(patron.additional_spells))
+		for(var/S in patron.additional_spells)
+			spelllist += S
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
@@ -122,6 +126,9 @@
 		return
 
 	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
+	if(length(patron.additional_spells))
+		for(var/S in patron.additional_spells)
+			spelllist += S
 	if(istype(patron,/datum/patron/elemental))
 		spelllist += /obj/effect/proc_holder/spell/invoked/lesser_heal
 	for(var/spell_type in spelllist)
@@ -155,6 +162,9 @@
 
 	granted_spells = list()
 	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
+	if(length(patron.additional_spells))
+		for(var/S in patron.additional_spells)
+			spelllist += S
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
@@ -172,6 +182,9 @@
 
 	granted_spells = list()
 	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
+	if(length(patron.additional_spells))
+		for(var/S in patron.additional_spells)
+			spelllist += S
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue

--- a/code/datums/gods/_patron.dm
+++ b/code/datums/gods/_patron.dm
@@ -34,6 +34,8 @@ GLOBAL_LIST_EMPTY(preference_patrons)
 	var/t3
 	/// Final tier spell
 	var/t4
+	/// Any additional spells that should be granted on spawn. These will be immediately available to priests, clerics, monks, and templars. NOT churchlings. 
+	var/list/additional_spells = list()
 
 /datum/patron/proc/on_gain(mob/living/pious)
 	for(var/trait in mob_traits)

--- a/code/datums/gods/patrons/elemental_pantheon.dm
+++ b/code/datums/gods/patrons/elemental_pantheon.dm
@@ -14,6 +14,7 @@
 	t2 = /obj/effect/proc_holder/spell/targeted/beasttame
 	t3 = /obj/effect/proc_holder/spell/targeted/conjure_glowshroom
 	t4 = /obj/effect/proc_holder/spell/invoked/revive
+	additional_spells = list(/obj/effect/proc_holder/spell/invoked/heal)
 	confess_lines = list(
 		"GOLDEN GREENING!",
 		"WE SPROUT ANEW!",

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -183,6 +183,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/miracle = FALSE
 	var/devotion_cost = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
+	var/devotion_unlockable = TRUE //Whether this spell can be unlocked via devotion. Spells that only priests should have access to should be set to FALSE
 
 	action_icon_state = "spell0"
 	action_icon = 'icons/mob/actions/roguespells.dmi'

--- a/code/modules/spells/spell_types/explosion.dm
+++ b/code/modules/spells/spell_types/explosion.dm
@@ -10,6 +10,7 @@
 	var/ex_light = 7
 	var/ex_flash = 25//You are going to get flashed
 	var/exp_fire = 9//even the caster is in danger
+	devotion_unlockable = FALSE
 
 /obj/effect/proc_holder/spell/targeted/explosion/cast(list/targets,mob/user = usr)
 	for(var/mob/living/target in targets)

--- a/html/changelogs/doxxmedearly - spellbugfixes.yml
+++ b/html/changelogs/doxxmedearly - spellbugfixes.yml
@@ -1,0 +1,10 @@
+
+author: doxxmedearly
+
+delete-after: True
+
+
+changes:
+  - rscadd: "Added a way to limit spells to priests, and to add patron spells outside of their tiered ones."
+  - bugfix: "Clerics and Templars of Visires no longer have access to Explosion. It is priest-only."
+  - bugfix: "Clerics and Templars of Gani have access to fortify once more."


### PR DESCRIPTION
Fixes #84
Added a way to grant additional patron spells that exist outside of the tier list. These are auto-granted so think of them as additional t0 spells, basically. 

Fixes #81
Added a variable to spells that can prevent them from being unlocked via devotion. Right now it's used to limit Visires' Explosion to priests, but it's good to have the option going forward. 