### PR TITLE
Mjallidhorn Spells Tweak

### DIFF
--- a/code/datums/gods/patrons/elemental_pantheon.dm
+++ b/code/datums/gods/patrons/elemental_pantheon.dm
@@ -28,8 +28,8 @@
 	worshippers = "Warriors, sellswords, justiciers and freedom fighters"
 	mob_traits = list(TRAIT_SOUL_EXAMINE, TRAIT_MJALLIDHORN_SWIM, TRAIT_DEATHSIGHT)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
-	t1 = /obj/effect/proc_holder/spell/invoked/avert
-	t2 = /obj/effect/proc_holder/spell/targeted/abrogation
+	t1 = /obj/effect/proc_holder/spell/targeted/abrogation
+	t2 = /obj/effect/proc_holder/spell/invoked/avert
 	t3 = /obj/effect/proc_holder/spell/targeted/soulspeak
 	t4 = /obj/effect/proc_holder/spell/targeted/burialrite
 	confess_lines = list(

--- a/html/changelogs/furrycactus - mjallidhorn_miracle_tweak.yml
+++ b/html/changelogs/furrycactus - mjallidhorn_miracle_tweak.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Swaps around the Borrowed Time and Abrogation miracles for Mjallidhorn clergy, so Templars of Mjallidhorn can actually use the Undead-hunter spell, while only Clerics and Priests can make use of the more healing-oriented spell."


### PR DESCRIPTION
  - rscadd: "Swaps around the tier spots for the Borrowed Time and Abrogation miracles for Mjallidhorn clergy, so Templars of Mjallidhorn can actually use the Undead-hunter spell, while only Clerics and Priests can make use of the more healing-oriented spell."