### PR TITLE
Templar Weapon Selection Additions

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -158,7 +158,7 @@
 
 /datum/outfit/job/roguetown/templar/crusader/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	var/weapons = list("Bastard Sword","Flail","Mace")
+	var/weapons = list("Bastard Sword","Flail","Mace","Zweihander","Lucerne")
 	var/weapon_choice = input(H,"Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	switch(weapon_choice)
 		if("Bastard Sword")
@@ -170,6 +170,15 @@
 		if("Mace")
 			H.put_in_hands(new /obj/item/rogueweapon/mace(H), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+		if("Zweihander")
+			H.put_in_hands(new /obj/item/rogueweapon/greatsword/grenz(H), TRUE)
+			H.put_in_hands(new /obj/item/gwstrap(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+		if("Lucerne")
+			H.put_in_hands(new /obj/item/rogueweapon/eaglebeak/lucerne(H), TRUE)
+			H.put_in_hands(new /obj/item/gwstrap(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+
 
 /datum/advclass/templar/heavyranger
 	name = "Ranger-Zealot"

--- a/html/changelogs/furrycactus - templar_weapons.yml
+++ b/html/changelogs/furrycactus - templar_weapons.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds two new weapons to Templar weapon selection - the Zweihander and the Lucerne, a greatsword and a polearm. Being large weapons, this means a Templar that selects them will have to forego their kite shield entirely to use them effectively."


### PR DESCRIPTION
  - rscadd: "Adds two new weapons to Templar weapon selection - the Zweihander and the Lucerne, a greatsword and a polearm. Being large weapons, this means a Templar that selects them will have to forego their kite shield entirely to use them effectively."