### PR TITLE
Removes triumph cost for Giant and No Flaw.

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Wood Arm (R)"=/datum/charflaw/limbloss/arm_r,
 	"Wood Arm (L)"=/datum/charflaw/limbloss/arm_l,
 	"Random or No Flaw"=/datum/charflaw/randflaw,
-	"No Flaw (3 TRIUMPHS)"=/datum/charflaw/noflaw
+	"No Flaw"=/datum/charflaw/eznoflaw
 	))
 
 /datum/charflaw

--- a/modular_azurepeak/virtues/size.dm
+++ b/modular_azurepeak/virtues/size.dm
@@ -2,7 +2,7 @@
 	name = "Giant"
 	desc = "I've always been larger, stronger and hardier than the average person. I tend to lumber around a lot, though..."
 	added_stats = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_SPEED = -2)
-	triumph_cost = 2
+	
 
 /datum/virtue/size/giant/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.transform = recipient.transform.Scale(1.25, 1.25)


### PR DESCRIPTION
Removes the triumph cost from Giant. It's just a statpack that gives you a stretchy sprite, it doesn't need to cost anything.

Also changes it so that no flaw requires no Triumphs to select, until we have more and better flaws this is something I've seen lots of people want and vices as they exist are a relic of an LRP past.
