### PR TITLE
Elemental Tabard Fixes

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -2129,6 +2129,10 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/cloak/templar/akan,
+/obj/item/clothing/cloak/templar/akan,
+/obj/item/clothing/cloak/templar/iliope,
+/obj/item/clothing/cloak/templar/iliope,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "chi" = (
@@ -16064,6 +16068,9 @@
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /obj/item/clothing/under/roguetown/chainlegs/iron,
 /obj/item/clothing/under/roguetown/heavy_leather_pants,
+/obj/item/clothing/cloak/templar/all_aspect,
+/obj/item/clothing/cloak/all_aspect,
+/obj/item/clothing/cloak/all_aspect/alt,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "qRH" = (
@@ -16542,12 +16549,21 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/item/clothing/neck/roguetown/psicross/visires,
 /obj/item/clothing/neck/roguetown/psicross/visires,
-/obj/item/clothing/head/roguetown/helmet/heavy/visires,
 /obj/item/clothing/cloak/templar/visires,
 /obj/item/clothing/cloak/templar/visires,
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/head/roguetown/helmet/heavy/visireshelm{
+	name = "helmet of visires"
+	},
+/obj/item/clothing/head/roguetown/helmet/heavy/visireshelm{
+	name = "helmet of visires"
+	},
+/obj/item/clothing/head/roguetown/helmet/heavy/visires,
+/obj/item/clothing/head/roguetown/helmet/heavy/visires,
+/obj/item/clothing/cloak/templar/visires/fire,
+/obj/item/clothing/cloak/templar/visires/fire,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "ruQ" = (
@@ -17818,10 +17834,11 @@
 /obj/item/clothing/cloak/templar/mjallidhorn,
 /obj/item/clothing/cloak/tabard/crusader/mjallidhorn,
 /obj/item/clothing/cloak/tabard/crusader/mjallidhorn,
-/obj/item/clothing/cloak/templar/iliope,
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/cloak/templar/mjallidhorn/frost,
+/obj/item/clothing/cloak/templar/mjallidhorn/frost,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "sHx" = (
@@ -19039,7 +19056,6 @@
 /obj/item/clothing/neck/roguetown/psicross/golerkanh,
 /obj/item/clothing/neck/roguetown/psicross/gani,
 /obj/item/clothing/neck/roguetown/psicross/gani,
-/obj/item/clothing/head/roguetown/helmet/heavy/golerkanh,
 /obj/item/clothing/cloak/templar/golerkanh,
 /obj/item/clothing/cloak/templar/gani,
 /obj/item/clothing/cloak/templar/gani,
@@ -19049,6 +19065,10 @@
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /obj/item/clothing/under/roguetown/chainlegs/iron,
+/obj/item/clothing/head/roguetown/helmet/heavy/golerkanh,
+/obj/item/clothing/head/roguetown/helmet/heavy/golerkanh,
+/obj/item/clothing/cloak/templar/golerkanh/earth,
+/obj/item/clothing/cloak/templar/golerkanh/earth,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "tRw" = (

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1107,10 +1107,10 @@
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	flags_inv = HIDECROTCH|HIDEBOOB
 
-/obj/item/clothing/cloak/templar/visires
+/obj/item/clothing/cloak/templar/visires/fire
 	name = "fire tabard"
 	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Visires, the Goddess of Fire on it."
-	icon_state = "tabard_astrata_alt"
+	icon_state = "tabard_astrata"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
 	boobed = TRUE
@@ -1149,7 +1149,7 @@
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	flags_inv = HIDECROTCH|HIDEBOOB
 
-/obj/item/clothing/cloak/templar/mjallidhorn
+/obj/item/clothing/cloak/templar/mjallidhorn/frost
 	name = "frost tabard"
 	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Mjallidhorn on it."
 	icon_state = "tabard_abyssor"
@@ -1163,7 +1163,7 @@
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	flags_inv = HIDECROTCH|HIDEBOOB
 
-/obj/item/clothing/cloak/templar/golerkanh
+/obj/item/clothing/cloak/templar/golerkanh/earth
 	name = "goler kanh tabard"
 	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Goler Kanh on it."
 	icon_state = "tabard_malum"

--- a/html/changelogs/furrycactus - elemental_tabard_fixes.yml
+++ b/html/changelogs/furrycactus - elemental_tabard_fixes.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Fixes several duplicated item path errors for the alt Goler Kahn, Frost, and Fire tabards."
+  - rscadd: "Mapped in the missing Air, Frost, Fire, and Goler Kahn tabards for templars."
+  - rscadd: "Moved the Iliope tabard from the Mjallidhorn chest to the Akan chest."
+  - rscadd: "Mapped in the alt Helmet of Visires to the Visires chest."


### PR DESCRIPTION
  - rscadd: "Fixes several duplicated item path errors for the alt Goler Kahn, Frost, and Fire tabards."
  - rscadd: "Mapped in the missing Air, Frost, Fire, and Goler Kahn tabards for templars."
  - rscadd: "Moved the Iliope tabard from the Mjallidhorn chest to the Akan chest."
  - rscadd: "Mapped in the alt Helmet of Visires to the Visires chest."