### PR TITLE
Gives the Priest a room

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -1991,6 +1991,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"cbR" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/church)
 "ccd" = (
 /obj/structure/fluff/railing/wood,
 /obj/machinery/light/rogue/torchholder/r{
@@ -11989,7 +11993,7 @@
 /area/rogue/indoors/town/magician)
 "mHJ" = (
 /obj/effect/landmark/start/priest,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church)
 "mIf" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -13163,6 +13167,14 @@
 /obj/structure/fermenting_barrel/zagul,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/basement/keep)
+"nPe" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stole/red,
+/obj/item/clothing/cloak/chasuble,
+/obj/item/rogueweapon/woodstaff/aries,
+/obj/item/roguekey/priest,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/church)
 "nPC" = (
 /obj/structure/fluff/railing/rampart{
 	dir = 4
@@ -13832,13 +13844,9 @@
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/under/town/basement)
 "owO" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stole/red,
-/obj/item/clothing/cloak/chasuble,
-/obj/item/rogueweapon/woodstaff/aries,
-/obj/machinery/light/rogue/torchholder/l,
-/obj/item/roguekey/priest,
-/turf/open/floor/rogue/woodturned,
+/obj/structure/bed/rogue,
+/obj/item/bedsheet/rogue/wool,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church)
 "owQ" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -17369,6 +17377,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"soS" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/church)
 "soZ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church";
@@ -20259,7 +20271,11 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/town/roofs/keep)
 "vip" = (
-/obj/structure/roguetent,
+/obj/structure/mineral_door/wood/donjon/stone{
+	lockid = "church";
+	name = "Church";
+	dir = 8
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "viA" = (
@@ -55331,9 +55347,9 @@ czi
 drC
 lQI
 lQI
-lQI
-lQI
-tKN
+dBv
+dBv
+soS
 jVy
 jVy
 jVy
@@ -55589,8 +55605,8 @@ lQI
 lQI
 ybq
 dBv
-dBv
-dBv
+cbR
+nPe
 jVy
 abn
 axa


### PR DESCRIPTION
Turns the priests starting tile + closet into a small room with a bed, closet and flooring to match the acolyte sleeping area behind a normal church door. Feels more appropriate than the current arrangement for the church leader.

![image](https://github.com/user-attachments/assets/8db68168-9cc6-449f-9a77-8233363ac568)

