### PR TITLE
Doubles Cautery Heat Time (because australians)

### DIFF
--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -162,7 +162,7 @@
 	update_heated(TRUE)
 	if(cool_timer)
 		deltimer(cool_timer)
-	cool_timer = addtimer(CALLBACK(src, PROC_REF(update_heated), FALSE), added SECONDS, TIMER_STOPPABLE)
+	cool_timer = addtimer(CALLBACK(src, PROC_REF(update_heated), FALSE), (added * 2) SECONDS, TIMER_STOPPABLE)
 
 /obj/item/rogueweapon/surgery/cautery/get_temperature()
 	if(heated)


### PR DESCRIPTION
Cautery stays heated for twice as long because ping makes the time tight. 