### PR TITLE
Give Court Magi Librarium access and make dungeon doors manor access

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -6394,7 +6394,7 @@
 "gEE" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "manor"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
@@ -11845,7 +11845,7 @@
 "mlQ" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "manor"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -15813,7 +15813,7 @@
 "qlp" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "manor"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10;

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -258,7 +258,7 @@
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
 
 /obj/item/storage/keyring/mage
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/tower, /obj/item/roguekey/mage)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/tower, /obj/item/roguekey/mage, /obj/item/roguekey/archive)
 
 /obj/item/storage/keyring/innkeep
 	keys = list(/obj/item/roguekey/tavern, /obj/item/roguekey/roomvi, /obj/item/roguekey/roomv, /obj/item/roguekey/roomiv, /obj/item/roguekey/roomiii, /obj/item/roguekey/roomii, /obj/item/roguekey/roomi, /obj/item/roguekey/tavernkeep)


### PR DESCRIPTION
Gives the Court Magi the archive key, as no wizard is complete without access to the library after all. Now there's a place they can rummage around for forbidden knowledge in. Additionally, the inner dungeon doors have been changed to manor access on request of Kyres. 
