### PR TITLE
Fixes Knight Titles Only Applying on Latejoin

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -35,7 +35,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
 	cloak = /obj/item/clothing/cloak/stabard/guardhood
 
-/datum/job/roguetown/captain/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/captain/after_spawn(mob/living/L, mob/M, latejoin)
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -22,7 +22,7 @@
 
 	cmode_music = 'sound/music/combat_knight.ogg'
 
-/datum/job/roguetown/knight/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/knight/after_spawn(mob/living/L, mob/M, latejoin)
 	..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L

--- a/html/changelogs/doxxmedearly - knighttitles.yml
+++ b/html/changelogs/doxxmedearly - knighttitles.yml
@@ -1,0 +1,5 @@
+author: doxxmedearly
+delete-after: True
+
+changes:
+  - bugfix: "Knights should now have their titles apply properly on spawn."


### PR DESCRIPTION
For some reason `latejoin` is forced to true on like every class's `afterequip()` and I don't know why, but it doesn't seem to mess with advanced setup for picking subjobs to just leave it unset. 
Somehow it was only giving latejoining knights their titles. This fixes that.
Edited it for captains too just to be sure.