### PR TITLE
Vomiting adjustments

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -560,7 +560,7 @@
 /mob/living/carbon/proc/handle_nausea()
 	if(nausea >= 100)
 		if(mob_timers["puke"])
-			if(world.time > mob_timers["puke"] + 16 SECONDS)
+			if(world.time > mob_timers["puke"] + 25 SECONDS)
 				mob_timers["puke"] = world.time
 				if(getorgan(/obj/item/organ/stomach))
 					to_chat(src, span_warning("I'm going to puke..."))
@@ -582,16 +582,25 @@
 
 	mob_timers["puke"] = world.time
 
-	if(nutrition <= 50 && !blood)
-		if(message)
-			emote("gag")
-		if(stun)
-			Immobilize(50)
-		return TRUE
 	if(!blood)
+		//Try to keep it in
+		if(STACON >= 11 && rand(min(STACON*3, 80)))
+			to_chat(src, span_warning("I almost vomit, but somehow I keep it down... for now."))
+			if(prob(40))
+				emote("gag")
+			add_nausea(-STACON)
+			return TRUE
+		//Not enough to vomit
+		if(nutrition <= 50)
+			if(message)
+				emote("gag")
+			if(stun)
+				Immobilize(50)
+			return TRUE
+		//Actually puke
 		if(HAS_TRAIT(src, TRAIT_NOHUNGER))
 			return TRUE
-		add_nausea(-100)
+		add_nausea(-150)
 		rogstam_add(-50)
 		if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
 			if(message)

--- a/code/modules/reagents/chemistry/reagents/roguetown.dm
+++ b/code/modules/reagents/chemistry/reagents/roguetown.dm
@@ -7,6 +7,6 @@
 
 /datum/reagent/miasmagas/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M, TRAIT_NOSTINK))
-		M.add_nausea(15)
+		M.add_nausea(10)
 		M.add_stress(/datum/stressevent/miasmagas)
 	return ..()

--- a/html/changelogs/doxxmedearly - stopschainpuking.yml
+++ b/html/changelogs/doxxmedearly - stopschainpuking.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - rscadd: "Extends time between vomit checks, reduces nausea more when vomiting, and adds a constitution check to hold back from vomiting, if your constitution is 11 or higher."
+  - rscadd: "Reduces how much nausea rot gives you per life tick."


### PR DESCRIPTION
Chainvomiting is awful. The following changes were made:

- Time between vomiting checks is now 25 seconds, up from 16.
- Vomiting reduces nausea by 150, up from 100
- Adds a constitution check. If CON is above average (11 or higher) there is a CHANCE that instead of vomiting, you will hold back, with an indication that you did. Does not apply if you would vomit blood. 
- The rate that rot increases your nausea has been reduced by 1/3. 