### PR TITLE
Devotion and Progression Fix

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -70,11 +70,9 @@
 
 /datum/devotion/proc/update_devotion(dev_amt, prog_amt, silent = FALSE)
 	devotion = clamp(devotion + dev_amt, 0, max_devotion)
-	//Max devotion limit
-	if((devotion >= max_devotion) && !silent)
-		to_chat(holder, span_warning("I have reached the limit of my devotion..."))
 	if(!prog_amt) // no point in the rest if it's just an expenditure
 		return TRUE
+	//Spell unlocking, based on progression
 	progression = clamp(progression + prog_amt, 0, max_progression)
 	var/obj/effect/proc_holder/spell/spell_unlocked
 	switch(level)
@@ -228,10 +226,16 @@
 	if(!devotion)
 		return FALSE
 
+	//Prevents "I conclude my prayer, I gained 0 devotion" message when clicking pray at max.
+	if(devotion.devotion >= devotion.max_devotion && devotion.progression >= CLERIC_REQ_4)
+		to_chat(src, span_notice("I am fully in tune with [devotion.patron.name]. I do not need to pray at this time."))
+		return TRUE
+
 	var/prayersesh = 0
 	visible_message("[src] kneels their head in prayer to the Gods.", "I kneel my head in prayer to [devotion.patron.name].")
 	for(var/i in 1 to 50)
-		if(devotion.devotion >= devotion.max_devotion)
+		//Stop only if we have both max devotion and max progression.
+		if(devotion.devotion >= devotion.max_devotion && devotion.progression >= CLERIC_REQ_4)
 			to_chat(src, span_warning("I have reached the limit of my devotion..."))
 			break
 		if(!do_after(src, 30))
@@ -241,7 +245,9 @@
 			devotion_multiplier += (mind.get_skill_level(/datum/skill/magic/holy) / SKILL_LEVEL_LEGENDARY)
 		var/prayer_effectiveness = round(devotion.prayer_effectiveness * devotion_multiplier)
 		devotion.update_devotion(prayer_effectiveness, prayer_effectiveness)
-		prayersesh += prayer_effectiveness
+		//Check prevents the final message from telling the player they gained more than they did
+		if(devotion.devotion < devotion.max_devotion)
+			prayersesh += prayer_effectiveness
 	visible_message("[src] concludes their prayer.", "I conclude my prayer.")
 	to_chat(src, "<font color='purple'>I gained [prayersesh] devotion!</font>")
 	return TRUE

--- a/html/changelogs/doxxmedearly - devotionfixes.yml
+++ b/html/changelogs/doxxmedearly - devotionfixes.yml
@@ -1,0 +1,9 @@
+
+author: doxxmedearly
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - rscadd: "Holy characters can now pray even at max devotion if they still need to unlock spells."
+  - rscadd: "Added better feedback message if you try to pray at max devotion and progression."


### PR DESCRIPTION
Fixes #133

Characters can now pray even at max devotion if they still need progression for spells. 
Added a better feedback message if you try to pray and don't need to. It tells you that you are in tune with your god and you don't need to pray further right now, instead of just instantly going "I conclude my prayer, I gain 0 devotion!"