### PR TITLE
Change Greater Fireball to have no movement interrupt

### DIFF
--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -220,7 +220,7 @@
 	charge_max = 10 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
-	movement_interrupt = TRUE
+	movement_interrupt = FALSE
 	chargedloop = /datum/looping_sound/invokefire
 	cost = 5
 	xp_gain = TRUE


### PR DESCRIPTION
This changes Greater Fireball so that it can be cast whilst moving like all the other offensive spells. As it stands currently the requirement that you remain rooted makes Greater Fireball worse than it's normal Fireball equivalent both in PVP and especially in PVE environments. 

PVE mobs move so fast that you can't gain distance on them and turn around for three seconds to fire a spell if you're solo without also killing yourself in the process, and if you're with a team they'll have moved in the way of your spell by the time you're done prepping it. 