### PR TITLE
Give Court Magicians Lightning Bolt 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -9,7 +9,7 @@
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
-	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
+	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
 	display_order = JDO_MAGICIAN
 	tutorial = "Your creed is one dedicated to the conquering of the arcane arts and the constant thrill of knowledge. \
 		You owe your life to the Lord, for it was his coin that allowed you to continue your studies in these dark times. \

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -220,7 +220,7 @@
 	charge_max = 10 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
-	movement_interrupt = FALSE
+	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokefire
 	cost = 5
 	xp_gain = TRUE

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -220,7 +220,7 @@
 	charge_max = 10 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
-	movement_interrupt = TRUE
+	movement_interrupt = FALSE
 	chargedloop = /datum/looping_sound/invokefire
 	cost = 5
 	xp_gain = TRUE


### PR DESCRIPTION
Court Magicians no longer loose their knowledge of Lightning Bolt when they stop being an apprentice. This saves having to buy it to get back to where you were before. 