### PR TITLE
Adjusts command report verb for setting

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -5,7 +5,7 @@
 	var/announcement
 
 	if (title && length(title) > 0)
-		announcement += "<h1 class='alert'>[title]</h1>"
+		announcement += "<span class='big bold'>[title]</span>"
 //		GLOB.news_network.SubmitArticle(text, "Captain's Announcement", "Station Announcements", null)
 /*
 	else
@@ -35,12 +35,12 @@
 
 /proc/print_command_report(text = "", title = null, announce=TRUE)
 	if(!title)
-		title = "Classified [command_name()] Update"
+		title = "Classified Missive"
 
 	if(announce)
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/blank.ogg')
+		priority_announce("A missive has been sent to the keep.", "News Arrives!", 'sound/misc/bell.ogg')
 
-	var/datum/comm_message/M  = new
+	var/datum/comm_message/M  = new /datum/comm_message
 	M.title = title
 	M.content =  text
 

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -34,18 +34,15 @@ SUBSYSTEM_DEF(communications)
 	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")
 
 /datum/controller/subsystem/communications/proc/send_message(datum/comm_message/sending,print = TRUE,unique = FALSE)
-	for(var/obj/machinery/computer/communications/C in GLOB.machines)
-		if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-			if(unique)
-				C.add_message(sending)
-			else //We copy the message for each console, answers and deletions won't be shared
-				var/datum/comm_message/M = new(sending.title,sending.content,sending.possible_answers.Copy())
-				C.add_message(M)
-			if(print)
-				var/obj/item/paper/P = new /obj/item/paper(C.loc)
-				P.name = "paper - '[sending.title]'"
-				P.info = sending.content
-				P.update_icon()
+	for(var/obj/structure/roguemachine/titan/T in SSroguemachine.titans)
+		T.say("A message arrives!")
+		playsound(T, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+		playsound(T, 'sound/misc/hiss.ogg', 100, FALSE, -1)
+		var/obj/item/paper/scroll/P = new /obj/item/paper/scroll(T.loc)
+		P.info = sending.content
+		P.update_icon()
+		//name last, name gets reset when icons are updated
+		P.name = "scroll - '[sending.title]'"
 
 #undef COMMUNICATION_COOLDOWN
 #undef COMMUNICATION_COOLDOWN_AI

--- a/code/controllers/subsystem/rogue/roguemachine.dm
+++ b/code/controllers/subsystem/rogue/roguemachine.dm
@@ -8,6 +8,7 @@ PROCESSING_SUBSYSTEM_DEF(roguemachine)
 	var/list/cameras = list()
 	var/list/scomm_machines = list()
 	var/list/stock_machines = list()
+	var/list/titans = list() //Yes there is usually only one, but in case there are multiple in future maps...
 	var/hermailermaster
 	var/list/death_queue = list()
 	var/last_death_report

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -549,25 +549,25 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/cmd_admin_create_centcom_report()
 	set category = "Special Verbs"
-	set name = "Create Command Report"
+	set name = "Create IC Announcement"
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/input = input(usr, "Enter a Command Report. Ensure it makes sense IC.", "What?", "") as message|null
+	var/input = input(usr, "Enter an announcement. Ensure it makes sense IC.", "What Say You?", "") as message|null
 	if(!input)
 		return
 
-	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No", "Cancel")
+	var/confirm = alert(src, "Do you want to announce the contents of the report to the players? If not, it will only arrive as a written message at the throne.", "Announce", "Yes", "No", "Cancel")
 	var/announce_command_report = TRUE
 	switch(confirm)
 		if("Yes")
-			priority_announce(input, null, 'sound/blank.ogg')
+			priority_announce(input, "News Arrives!", 'sound/misc/bell.ogg')
 			announce_command_report = FALSE
 		if("Cancel")
 			return
 
-	print_command_report(input, "[announce_command_report ? "Classified " : ""][command_name()] Update", announce_command_report)
+	print_command_report(input, "", announce_command_report)
 
 	log_admin("[key_name(src)] has created a command report: [input]")
 	message_admins("[key_name_admin(src)] has created a command report")

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -34,11 +34,13 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 
 /obj/structure/roguemachine/titan/Destroy()
 	set_light(0)
+	SSroguemachine.titans -= src
 	..()
 
 /obj/structure/roguemachine/titan/Initialize()
 	. = ..()
 	icon_state = null
+	SSroguemachine.titans += src
 //	var/mutable_appearance/eye_lights = mutable_appearance(icon, "titan-eyes")
 //	eye_lights.plane = ABOVE_LIGHTING_PLANE //glowy eyes
 //	eye_lights.layer = ABOVE_LIGHTING_LAYER


### PR DESCRIPTION
Changes "Create Command Report" to "Make IC Announcement"
Using this verb will also create a scroll that appears on the throne.

"A report has been downloaded and printed out at all communications consoles" -> "A missive arrives at the keep"
"Incoming Classified Message" -> "News Arrives!" (Also makes the text a tiny bit smaller for the bigass title)
The announcement bell sound plays when one is made.

Titan is now added to SSroguemachines

Known bugs: 
-The scroll that is created seems to not use the actual parchment UI, and is instead a text box. Unsure what the cause is. It is, however, still readable. 
