### PR TITLE
Fixes adjust_spellpoints runtimes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -143,7 +143,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron) // This creates the cleric holder used for devotion spells
 	C.grant_spells_priest(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-	H.mind.adjust_spellpoints(-4)//You already have like 10 spells lmao
+	if(H.mind)
+		H.mind.adjust_spellpoints(-4)//You already have like 10 spells lmao
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -72,7 +72,8 @@
 	var/datum/devotion/C = new /datum/devotion(H, H.patron) // This creates the cleric holder used for devotion spells
 	C.grant_spells_priest(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-	H.mind.adjust_spellpoints(-4)//You already have like 10 spells lmao
+	if(H.mind)
+		H.mind.adjust_spellpoints(-4)//You already have like 10 spells lmao
 
 /datum/advclass/heir/aristocrat
 	name = "Unawakened Blood"
@@ -123,4 +124,5 @@
 	var/datum/devotion/C = new /datum/devotion(H, H.patron) // This creates the cleric holder used for devotion spells
 	C.grant_spells_priest(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-	H.mind.adjust_spellpoints(-4)//You already have like 10 spells lmao
+	if(H.mind)
+		H.mind.adjust_spellpoints(-4)//You already have like 10 spells lmao


### PR DESCRIPTION
`Adjust_spellpoints()` was causing runtimes as a prince/reagent in the setup menu because it did not check for `H.mind` which is `null` in the character preview