### PR TITLE
Makes manuscript making more user-friendly

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -445,6 +445,9 @@
 				user.put_in_inactive_hand(M)
 			. = ..()
 			return qdel(src)
+		else
+			to_chat(user, span_notice("Both pages need to be written upon if I am to make a proper manuscript."))
+			return
 
 	if(!P.can_be_package_wrapped())
 		return ..()


### PR DESCRIPTION
Notifies the user on how to make a manuscript since it's not intuitive and there's no feedback; if someone tries, they'll end up wrapping the paper instead. Now it lets them know. 