### PR TITLE
Half-Elf Skin Tones

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -71,12 +71,26 @@
 
 /datum/species/human/halfelf/get_skin_list()
 	return list(
-		"Timber-Gronn" = SKIN_COLOR_TIMBER_GRONN,
-		"Giza-Azure" = SKIN_COLOR_GIZA_AZURE,
-		"Walnut-Stine" = SKIN_COLOR_WALNUT_STINE,
-		"Etrustcan-Dandelion" = SKIN_COLOR_ETRUSTCAN_DANDELION,
-		"Naledi-Born" = SKIN_COLOR_NALEDI_BORN,
-		"Kaze-Lotus" = SKIN_COLOR_KAZE_LOTUS
+		"Amber Lands" = SKIN_COLOR_GRENZELHOFT,
+		"Aelondan" = SKIN_COLOR_HAMMERHOLD,
+		"True Qadirid" = SKIN_COLOR_AVAR,
+		"Rinlette" = SKIN_COLOR_ROCKHILL,
+		"Nomablood" = SKIN_COLOR_OTAVA,
+		"Arnkin" = SKIN_COLOR_ETRUSCA,
+		"Wrestchilde" = SKIN_COLOR_GRONN,
+		"Jinman" = SKIN_COLOR_GIZA,
+		"Sunnite" = SKIN_COLOR_SHALVISTINE,
+		"Imperial Kui" = SKIN_COLOR_LALVESTINE,
+		"Ginsoyon" = SKIN_COLOR_NALEDI,
+		"Yi Freemen" = SKIN_COLOR_KAZENGUN,
+		"Sanct of Aelonda" = SKIN_COLOR_DANDELION_CREEK,
+		"Saint's Rest" = SKIN_COLOR_ROSEVEIL,
+		"Amberling" = SKIN_COLOR_AZUREGROVE,
+		"Nortmidst" = SKIN_COLOR_ARBORSHOME,
+		"Old Arnkin" = SKIN_COLOR_ALMONDVALLE,
+		"The Far Wild" = SKIN_COLOR_WALNUT_WOODS,
+		"Manesi Lowland" = SKIN_COLOR_TIMBERBORN,
+		"The Delve" = SKIN_COLOR_LOTUS_COAST
 	)
 
 /datum/species/human/halfelf/get_hairc_list()

--- a/html/changelogs/furrycactus - half_elf_skin_tones.yml
+++ b/html/changelogs/furrycactus - half_elf_skin_tones.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Gives Half-Elves more lore-compliant skin tone selection instead of Azure Peak ones, and allows them to pick any of the selections available to Humans or Elves."


### PR DESCRIPTION
  - rscadd: "Gives Half-Elves more lore-compliant skin tone selection instead of Azure Peak ones, and allows them to pick any of the selections available to Humans or Elves."
