### PR TITLE
Katholikos and Inquisition Job Tweaks

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -8026,14 +8026,14 @@
 /area/rogue/outdoors/town)
 "irD" = (
 /obj/machinery/light/rogue/torchholder/r,
-/obj/item/clothing/neck/roguetown/psicross,
 /obj/structure/table/wood{
 	dir = 10;
 	icon_state = "largetable"
 	},
-/obj/item/clothing/neck/roguetown/psicross{
-	pixel_x = 9
+/obj/item/clothing/neck/roguetown/psicross/silver{
+	pixel_y = 9
 	},
+/obj/item/clothing/neck/roguetown/psicross/silver,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/church)
 "isa" = (
@@ -16391,9 +16391,6 @@
 /obj/item/rogueweapon/huntingknife/idagger/silver,
 /obj/item/rogueweapon/huntingknife/cleaver/combat,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/neck/roguetown/psicross/g,
-/obj/item/clothing/neck/roguetown/psicross,
-/obj/item/clothing/neck/roguetown/psicross/wood,
 /obj/item/clothing/head/roguetown/helmet/heavy/all_aspect,
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
@@ -16402,6 +16399,10 @@
 /obj/item/clothing/cloak/templar/all_aspect,
 /obj/item/clothing/cloak/all_aspect,
 /obj/item/clothing/cloak/all_aspect/alt,
+/obj/item/clothing/neck/roguetown/psicross/wood/katholikos,
+/obj/item/clothing/neck/roguetown/psicross,
+/obj/item/clothing/neck/roguetown/psicross/g,
+/obj/item/clothing/neck/roguetown/psicross/silver,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "qRH" = (

--- a/code/datums/gods/patrons/all_aspect.dm
+++ b/code/datums/gods/patrons/all_aspect.dm
@@ -4,8 +4,12 @@
 	desc = "The balance between the Elementals is always adhered to, but the worshippers most keen to maintain the balance are those of the Katholikos."
 	worshippers = "Fanatics, acolytes and inquisitors"
 	associated_faith = /datum/faith/all_aspect
-	amulet = /obj/item/clothing/neck/roguetown/psicross
+	amulet = /obj/item/clothing/neck/roguetown/psicross/silver
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
+	t1 = /obj/effect/proc_holder/spell/invoked/push_spell // Dark Souls wrath of the gods
+	t2 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue // Divine fire. Light the heretics' pyre. Nobody is able to get this high on All-Aspect anyway so t2 and beyond are kinda moot. But something for future plans maybe.
+	t3 = /obj/effect/proc_holder/spell/invoked/blade_burst // Be attacked by unaspected holy energy or something. All-Aspect is the balance, so it being amorphous energy instead of any one element seems neat.
+	t4 = /obj/effect/proc_holder/spell/invoked/revive // If powerful All-Aspect clergy somehow ever shows up, being able to revive people seems good. Gani and Akan both can.
 	confess_lines = list(
 		"THE BALANCE COMMANDS!",
 		"THE ASPECTS PREVAIL!",

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -34,7 +34,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	mask = /obj/item/clothing/mask/rogue/facemask
 	head = /obj/item/clothing/head/roguetown/roguehood/black
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1, /obj/item/lockpickring/mundane = 1)
+	backpack_contents = list(/obj/item/storage/keyring/puritan = 1, /obj/item/lockpickring/mundane = 1)
 	H.change_stat("strength", -1) // weasel
 	H.change_stat("endurance", 3)
 	H.change_stat("perception", 2)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -18,7 +18,7 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	id = /obj/item/clothing/ring/silver
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
+	backpack_contents = list(/obj/item/storage/keyring/puritan = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE) 
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -67,7 +67,7 @@
 			H.put_in_hands(new /obj/item/rogueweapon/mace(H), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
 		if("Zweihander")
-			H.put_in_hands(new /obj/item/rogueweapon/greatsword/grenz(H), TRUE)
+			H.put_in_hands(new /obj/item/rogueweapon/greatsword/zwei(H), TRUE)
 			H.put_in_hands(new /obj/item/gwstrap(H), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Lucerne")

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -24,7 +24,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	id = /obj/item/clothing/ring/silver
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
+	backpack_contents = list(/obj/item/storage/keyring/puritan = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -54,7 +54,7 @@
 
 /datum/outfit/job/roguetown/katholikostemplar/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	var/weapons = list("Bastard Sword","Flail","Mace")
+	var/weapons = list("Bastard Sword","Flail","Mace","Zweihander","Lucerne")
 	var/weapon_choice = input(H,"Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	switch(weapon_choice)
 		if("Bastard Sword")
@@ -66,3 +66,11 @@
 		if("Mace")
 			H.put_in_hands(new /obj/item/rogueweapon/mace(H), TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+		if("Zweihander")
+			H.put_in_hands(new /obj/item/rogueweapon/greatsword/grenz(H), TRUE)
+			H.put_in_hands(new /obj/item/gwstrap(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+		if("Lucerne")
+			H.put_in_hands(new /obj/item/rogueweapon/eaglebeak/lucerne(H), TRUE)
+			H.put_in_hands(new /obj/item/gwstrap(H), TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -16,7 +16,6 @@
 	spawn_positions = 99
 	advclass_cat_rolls = list(CTAG_TEMPLAR = 20)
 	display_order = JDO_TEMPLAR
-	cmode_music = 'sound/music/templarofpsydonia.ogg'
 	
 	give_bank_account = TRUE
 

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -16,6 +16,7 @@
 	spawn_positions = 99
 	advclass_cat_rolls = list(CTAG_TEMPLAR = 20)
 	display_order = JDO_TEMPLAR
+	cmode_music = 'sound/music/templarofpsydonia.ogg'
 	
 	give_bank_account = TRUE
 

--- a/html/changelogs/furrycactus - katholikos_roles_update.yml
+++ b/html/changelogs/furrycactus - katholikos_roles_update.yml
@@ -56,7 +56,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Adds the current weapon selection that Templar has to Adjudicator."
-  - rscadd: "Adds the current combat music that Adjudicator has to Templar."
   - rscadd: "Adds some T1-4 spells for the All-Aspect, even though anything beyond T1 is redundant."
   - rscadd: "Swaps out some generic psycrosses for proper silver psycrosses, both on the map and on some Inquisition roles."
   - rscadd: "Gives proper Inquisition keyrings to the Orthodoxist roles, otherwise they can't actually unlock the churchling quarters."

--- a/html/changelogs/furrycactus - katholikos_roles_update.yml
+++ b/html/changelogs/furrycactus - katholikos_roles_update.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the current weapon selection that Templar has to Adjudicator."
+  - rscadd: "Adds the current combat music that Adjudicator has to Templar."
+  - rscadd: "Adds some T1-4 spells for the All-Aspect, even though anything beyond T1 is redundant."
+  - rscadd: "Swaps out some generic psycrosses for proper silver psycrosses, both on the map and on some Inquisition roles."

--- a/html/changelogs/furrycactus - katholikos_roles_update.yml
+++ b/html/changelogs/furrycactus - katholikos_roles_update.yml
@@ -59,3 +59,4 @@ changes:
   - rscadd: "Adds the current combat music that Adjudicator has to Templar."
   - rscadd: "Adds some T1-4 spells for the All-Aspect, even though anything beyond T1 is redundant."
   - rscadd: "Swaps out some generic psycrosses for proper silver psycrosses, both on the map and on some Inquisition roles."
+  - rscadd: "Gives proper Inquisition keyrings to the Orthodoxist roles, otherwise they can't actually unlock the churchling quarters."


### PR DESCRIPTION
  - rscadd: "Adds the current weapon selection that Templar has to Adjudicator."
  - rscadd: "Adds some T1-4 spells for the All-Aspect, even though anything beyond T1 is redundant."
  - rscadd: "Swaps out some generic psycrosses for proper silver psycrosses, both on the map and on some Inquisition roles."
  - rscadd: "Gives proper Inquisition keyrings to the Orthodoxist roles, otherwise they can't actually unlock the churchling quarters."
