### PR TITLE
Sewing Without a Table

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -86,9 +86,6 @@
 		if(user.mind.get_skill_level(/datum/skill/misc/sewing) < I.required_repair_skill)
 			to_chat(user, span_warning("I don't know how to repair this..."))
 			return
-		if(!I.ontable())
-			to_chat(user, span_warning("I should put this on a table first."))
-			return
 		playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 		var/sewtime = 70
 		if(user.mind)

--- a/html/changelogs/furrycactus - sewing_without_table.yml
+++ b/html/changelogs/furrycactus - sewing_without_table.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ""
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Removes the requirement of a table for repairing cloth or leather armour."


### PR DESCRIPTION
Removes the requirement of a table for repairing cloth and leather.

Weird to me that armour can be repaired with a hammer anywhere, but you specifically need a table to stitch up a tear on your shirt, when the latter is something far easier to do on the fly.