### PR TITLE
Cleans up species list

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -28,10 +28,6 @@
 //Races we are currently not using
 #define RACES_UNUSED\
 	/datum/species/goblinp,\
-	/datum/species/lizardfolk,\
-	/datum/species/tabaxi,\
-	/datum/species/lupian,\
-	/datum/species/demihuman,\
 	/datum/species/kobold\
 	/datum/species/anthromorphsmall,\
 

--- a/html/changelogs/peppermint - species_additions.yml
+++ b/html/changelogs/peppermint - species_additions.yml
@@ -56,4 +56,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Enables tiefling and half-orc to limited jobs."
+  - rscadd: "Enables the other two races that should already have been on."
   


### PR DESCRIPTION
These species were already turned on, just had multiple definitions. They will have worked fine regardless, this just makes it a bit cleaner.