### PR TITLE
Delete All Instance of the Mercenary Key

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -6790,7 +6790,6 @@
 /obj/item/roguekey/dungeon,
 /obj/item/roguekey/graveyard,
 /obj/item/roguekey/garrison,
-/obj/item/roguekey/mercenary,
 /obj/item/roguekey/tavern,
 /obj/item/roguekey/merchant,
 /obj/item/roguekey/physician,

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -315,7 +315,7 @@
 	icon_state = "brownkey"
 	lockid = "nightmaiden"
 
-/obj/item/roguekey/mercenary
+/obj/item/roguekey/mercenary // Currently unused for anything, as the adventurer's guild in the tavern is unlocked for the public
 	name = "mercenary key"
 	desc = "Why, a mercenary would not kick doors down."
 	icon_state = "greenkey"

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
@@ -25,7 +25,7 @@
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	backr = /obj/item/gwstrap
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor)
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/condottiero.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/condottiero.dm
@@ -21,7 +21,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger/navaja)
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger/navaja)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 5, TRUE) //Possibly too high, no idea.
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -85,5 +85,5 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	H.grant_language(/datum/language/celestial)
 
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal)
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -77,6 +77,6 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backl = /obj/item/gwstrap
 
-	backpack_contents = list(/obj/item/roguekey/mercenary)
+	backpack_contents = list()
 
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -25,7 +25,7 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backr = /obj/item/storage/backpack/rogue/satchel
 	l_hand = /obj/item/rogueweapon/shield/buckler
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor)
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
@@ -24,7 +24,7 @@
 	beltr = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backr = /obj/item/rogueweapon/shield/wood
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor)
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -74,7 +74,7 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/hierophant
 			shirt = /obj/item/clothing/suit/roguetown/shirt/robe/hierophant
 			pants = /obj/item/clothing/under/roguetown/trou/leather
-			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife)
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife)
 
 		if("Pontifex")//TBD-Class Overhaul
 			H.set_blindness(0)
@@ -101,7 +101,7 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex
 			shirt = /obj/item/clothing/suit/roguetown/shirt/robe/pointfex
 			pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex
-			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife)
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife)
 
 		if("Vizier")//TBD-Class Overhaul
 			H.set_blindness(0)
@@ -142,7 +142,7 @@
 			else
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord // FUCK YOU ZETH, WHY DOESN'T THE ARMING JACKET GET WOMEN SPRITES.
 
-				backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife)
+				backpack_contents = list(/obj/item/rogueweapon/huntingknife)
 
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_spells_templar(H)

--- a/html/changelogs/mofo1995 - remove_merc_key.yml
+++ b/html/changelogs/mofo1995 - remove_merc_key.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: "Your_Name"
+author: "Mofo1995"
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Add feature here."
-  - bugfix: "Bug fix here."
+  - rscel: "Removes mercenary key from spawn loadouts and grand treasury."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes all instances of the mercenary key both from starting loadouts and from the crate in the grand treasury.

## Why It's Good For The Game

Since the adventurer's guild bunkroom in the inn is unlocked and open to everyone, and can't even be locked with the mercenary key, it's a redundant key which goes to absolutely no locks. It remains in the code in case it should be added back later.
