### PR TITLE
Disables testing mode

### DIFF
--- a/code/rt.dm
+++ b/code/rt.dm
@@ -1,6 +1,6 @@
 //uncomment FASTLOAD to change to a much faster loading debugging map
 #ifndef TESTING
-    #define FASTLOAD
+//    #define FASTLOAD
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif

--- a/html/changelogs/4-11-2025-fixes_testing_mode.yml
+++ b/html/changelogs/4-11-2025-fixes_testing_mode.yml
@@ -1,0 +1,6 @@
+author: "kyres1"
+
+delete-after: True
+
+changes:
+  - bugfix: "Disables testing mode again."


### PR DESCRIPTION
If you leave this enabled, a lot of shit breaks on live.

We'll add this to gitignore soon
