### PR TITLE
Ranger-Knight Subclass Fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -110,10 +110,11 @@
 			belt = /obj/item/storage/belt/rogue/leather
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 			cloak = /obj/item/clothing/cloak/tabard
-			beltr = /obj/item/flashlight/flare/torch/lantern
 			beltl = /obj/item/rogueweapon/sword/iron/short
+			backl = /obj/item/storage/backpack/rogue/satchel
 			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 			head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger = 1, /obj/item/flashlight/flare/torch/lantern)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
@@ -139,7 +140,7 @@
 					H.put_in_hands(new /obj/item/quiver/arrows(H), FALSE)
 					H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 				if("Longbow")
-					H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve(H), FALSE)
+					H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow(H), FALSE)
 					H.put_in_hands(new /obj/item/quiver/arrows(H), FALSE)
 					H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 				if("Crossbow")

--- a/html/changelogs/furrycactus - ranger_knight_fix.yml
+++ b/html/changelogs/furrycactus - ranger_knight_fix.yml
@@ -1,0 +1,55 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Gives Ranger-Knight its missing satchel."
+  - rscdel: "Fixes the duplicate recurve bow selection."


### PR DESCRIPTION
- Gives Ranger-Knight its missing satchel.
- Fixes the duplicate Recurve Bow selection.