### PR TITLE
Adds hood back to loadout item list

### DIFF
--- a/html/changelogs/ClemTheDuckHoodFix.yml
+++ b/html/changelogs/ClemTheDuckHoodFix.yml
@@ -1,0 +1,55 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "ClemTheDuck"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "fixes a small bug that saw the hood item not selectable in the loadout."
+ 

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -62,7 +62,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Duelist's Hat"
 	path = /obj/item/clothing/head/roguetown/duelhat
 
-/datum/loadout_item/hood
+/datum/loadout_item/rhood
 	name = "Hood"
 	path = /obj/item/clothing/head/roguetown/roguehood
 


### PR DESCRIPTION
two items shared the datum name "hood" so the roguehood item was being overridden and not appearing in the loadout item menu. This pr changes the datum name for the item to "rhood".
