### PR TITLE
Tweaks Arcyne Potential

### DIFF
--- a/html/changelogs/hocka-arcynepotentialtweaks.yml
+++ b/html/changelogs/hocka-arcynepotentialtweaks.yml
@@ -1,0 +1,8 @@
+
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - bugfix: "Arcyne Potential now assigns Prestidigitation regardless of the recipient's arcane skill level."
+  - refactor: "Rearranged the proc for Arcyne Potential a bit for more readability, and so that it actually gives out Prestidigitation like it's supposed to.""

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -6,16 +6,13 @@
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 		recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		to_chat(recipient, span_warning("PREST CHECK PASSED"))
 
 	var/skill_level = recipient.mind?.get_skill_level(/datum/skill/magic/arcane)
 	if (skill_level == 0) // we can do this because apply_to is always called first
 		recipient.mind?.adjust_spellpoints(-6) // no martial-arcyne for you - not the intent of this virtue!
-		to_chat(recipient, span_warning("ARCANE SKILL CHECK PASSED"))
 	if (skill_level >= 1)
 		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT))
 			recipient.mind?.adjust_spellpoints(1) // 1 extra spellpoint if you're already arcane
-			to_chat(recipient, span_warning("ARMOUR SKILL CHECK PASSED"))
 		else
 			to_chat(recipient, span_notice("I'm too trained in defensive tactics for my Virtue to benefit my spell knowledge any further."))
 

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -4,13 +4,18 @@
 	added_skills = list(/datum/skill/magic/arcane = 1)
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
-	if (!recipient.mind?.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
+	if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
+		recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+		to_chat(recipient, span_warning("PREST CHECK PASSED"))
+
+	var/skill_level = recipient.mind?.get_skill_level(/datum/skill/magic/arcane)
+	if (skill_level == 0) // we can do this because apply_to is always called first
 		recipient.mind?.adjust_spellpoints(-6) // no martial-arcyne for you - not the intent of this virtue!
-		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
-			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-	else
+		to_chat(recipient, span_warning("ARCANE SKILL CHECK PASSED"))
+	if (skill_level >= 1)
 		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT))
 			recipient.mind?.adjust_spellpoints(1) // 1 extra spellpoint if you're already arcane
+			to_chat(recipient, span_warning("ARMOUR SKILL CHECK PASSED"))
 		else
 			to_chat(recipient, span_notice("I'm too trained in defensive tactics for my Virtue to benefit my spell knowledge any further."))
 


### PR DESCRIPTION
Ensures that Arcyne Potential does a check for addking Prestidigitation _regardless_ of if whether or not the user has arcane skill already, as well as refactors the checks for a bit more readability.


I'm pretty sure there's probably a better way to rewrite this, but here you go, let me have my fucking Prestidigitation.