### PR TITLE
Fixes the Night-Eyed virtue

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -30,7 +30,7 @@
 	var/eye_icon_state = "eyes"
 	var/flash_protect = FLASH_PROTECTION_NONE
 	var/see_invisible = SEE_INVISIBLE_LIVING
-	var/lighting_alpha
+	var/lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	var/no_glasses
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
 

--- a/html/changelogs/cometblaze-night_eyed_fix.yml
+++ b/html/changelogs/cometblaze-night_eyed_fix.yml
@@ -1,0 +1,54 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "CometBlaze"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the Night-Eyed virtue so it now does what it's supposed to."


### PR DESCRIPTION
The game wasn't applying the `lighting_alpha` correctly since the variable's default value was `NULL`. This fixes it by making it so `lighting_alpha` starts out at `LIGHTING_PLANE_ALPHA_VISIBLE` which is the normal value for mobs without nightvision.
