### PR TITLE
Petty Thief Lockpick Ring Fix

### DIFF
--- a/html/changelogs/furrycactus - petty_thief_lockpickring.yml
+++ b/html/changelogs/furrycactus - petty_thief_lockpickring.yml
@@ -1,0 +1,54 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Fixes the item path for the lockpick ring granted by the Petty Thief virtue."

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -89,7 +89,7 @@
 /datum/virtue/utility/petty_thief
 	name = "Petty Thief"
 	desc = "You have spent time on the wrong side of the law, learning how to break locks and liberate posessions. "
-	added_stashed_items = list(/obj/item/lockpickring)
+	added_stashed_items = list(/obj/item/lockpickring/mundane)
 	added_skills = list(list(/datum/skill/misc/stealing, 3, 5),
 						list(/datum/skill/misc/lockpicking, 3, 3),
 	)


### PR DESCRIPTION
Fixes the item path for the lockpick ring given by the Petty Thief virtue.