### PR TITLE
Survival-related tweaks

### DIFF
--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -26,7 +26,7 @@
 	desc = "Bronze tubes spiral about from the mouth of this waterskin in complex, dizzying patterns."
 	icon_state = "water-purifier"
 	desc_uncorked = "Bronze tubes spiral about from the mouth of this waterskin in complex, dizzying patterns. The cap on the mouth is off."
-	var/filtered_reagents = list(/datum/reagent/water/gross) // List of liquids it turns into drinkable water
+	var/filtered_reagents = list(/datum/reagent/water/gross, /datum/reagent/water/salt) // List of liquids it turns into drinkable water
 
 /obj/item/reagent_containers/glass/bottle/waterskin/purifier/onfill(obj/target, mob/user, silent = FALSE)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -270,7 +270,7 @@
 
 
 /obj/item/rogueweapon/huntingknife/stoneknife
-	possible_item_intents = list(/datum/intent/dagger/cut,/datum/intent/dagger/chop)
+	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut,/datum/intent/dagger/chop)
 	name = "stone knife"
 	desc = "A crudely crafted knife, made of stone."
 	icon_state = "stone_knife"

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -20,6 +20,17 @@
 		return
 	return ..()
 
+/obj/structure/flora/newtree/attackby(obj/item/W, mob/living/user)
+	..()
+
+	if(istype(W, /obj/item/rogueweapon/stoneaxe) && user.used_intent.blade_class == BCLASS_CHOP) // not much point in running this loop if you aren't on chop intent
+		user.changeNext_move(CLICK_CD_MELEE)
+		while(Adjacent(user))
+			if(do_after(user, 20, target = src))
+				..()
+			else
+				break
+
 /obj/structure/flora/newtree/attack_right(mob/user)
 	if(user.mind && isliving(user))
 		if(user.mind.special_items && user.mind.special_items.len)

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -390,7 +390,7 @@
 	slowdown = 4
 	swim_skill = TRUE
 	wash_in = TRUE
-	water_reagent = /datum/reagent/water/gross
+	water_reagent = /datum/reagent/water/salt
 
 /turf/open/water/ocean
 	desc = "Thin and muddied water of a coast, it only appears deep enough to reach a one's knees."

--- a/code/modules/farming/crafting_recipes.dm
+++ b/code/modules/farming/crafting_recipes.dm
@@ -69,6 +69,16 @@
 	craftsound = null
 	skillcraft = null
 
+/datum/crafting_recipe/roguetown/gathersalt
+	name = "gather salt pile"
+	result = /obj/item/reagent_containers/powder/salt
+	reqs = list(/datum/reagent/consumable/sodiumchloride = 15)
+	time = 2 SECONDS
+	verbage_simple = "gather"
+	verbage = "gathers"
+	craftsound = null
+	skillcraft = null
+
 /datum/crafting_recipe/roguetown/sigdry
 	name = "westleach zig"
 	result = /obj/item/clothing/mask/cigarette/rollie/nicotine

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -166,6 +166,17 @@
 		M.add_nausea(50)
 	return ..()
 
+/datum/reagent/water/salt
+	taste_description = "salt"
+	hydration = -12 // drinking saltwater dehydrates you, duh
+
+/datum/chemical_reaction/boil_saltwater
+	name = "Boiled Saltwater"
+	id = "boilsaltwater"
+	results = list(/datum/reagent/consumable/sodiumchloride = 15)
+	required_reagents = list(/datum/reagent/water/salt = 99) // a full pot of saltwater
+	required_temp = 374
+
 /*
  *	Water reaction to turf
  */

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -43,13 +43,21 @@
 
 /datum/crafting_recipe/roguetown/alchemy/salt
 	name = "Salt Pile"
-	result = list(/obj/item/reagent_containers/powder/salt)
+	result = list(
+				/obj/item/reagent_containers/powder/salt,
+				/obj/item/reagent_containers/powder/salt,
+				/obj/item/reagent_containers/powder/salt
+				)
 	reqs = list(/obj/item/ash = 1, /datum/reagent/water = 10, /obj/item/reagent_containers/food/snacks/fat = 1)
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/alchemy/salt_2
 	name = "Salt Pile"
-	result = list(/obj/item/reagent_containers/powder/salt)
+	result = list(
+				/obj/item/reagent_containers/powder/salt,
+				/obj/item/reagent_containers/powder/salt,
+				/obj/item/reagent_containers/powder/salt
+				)
 	reqs = list(/obj/item/ash = 1, /datum/reagent/water = 10, /obj/item/reagent_containers/food/snacks/rogue/meat/mince = 1)
 	craftdiff = 0
 

--- a/html/changelogs/hocka-survivalfixes.yml
+++ b/html/changelogs/hocka-survivalfixes.yml
@@ -1,0 +1,10 @@
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - bugfix: "Added stab intent to stone knives, letting them be used for cooking meat over a campfire."
+  - rscadd: "Added a new salt water subtype for the water reagent - drinking it lowers hydrations but it can be filtered by purifier waterskins. If you gather a full pot of it you can boil it to get the salt out."
+  - rscadd: "New crafting recipe, mostly a side-fix for transferring the chemical reagent version of salt into the salt pile item, needed for cooking recipes. "
+  - balance: "The salt alchemy recipe now outputs 3 piles of salt instead of one to hopefully keep it competitive with the new source of salt."
+  - qol: "Clicking on a tree trunk with either a stone axe or woodcutting axe on chop intent will now automatically cycle through the hits for you, much like blacksmithing."


### PR DESCRIPTION
(Sorry Kyres)

- Gave stab intent to stone knives to let them be usable for cooking food over campfires
- Added reagent/water/salt, this goes in the ocean water turfs. Salt water won't poison you like "gross" water, but it dehydrates you instead of hydrating. Filling a pot up with it and leaving it to boil over a hearth leaves you with some salt leftovers in the pot, and you can use the crafting menu to essentially turn that 15u of salt into a salt pile. Would genuinely like some feedback on better ideas on how to handle this though, as I'm worried this might feel a little bit janky? However I couldn't think of a neater way to do it.

- Making salt via alchemy now gives you 3 piles of salt in the hopes it'll keep the recipe competitive with the new source.
- Using a stone axe or woodcutting axe with chop intent selected on a tree should now process all the hits for you, much like how blacksmithing is handled. RSI Begone!

In a sleep-deprived stupor as I made the later end of some of this code and the PR itself, scream at me if I've missed something critical before merging please.