### PR TITLE
Adds customisability to Local, Direct and Global Narrates + some new font defines

### DIFF
--- a/code/__DEFINES/font_changers.dm
+++ b/code/__DEFINES/font_changers.dm
@@ -1,0 +1,15 @@
+//shape changes
+#define FONT_BOLD(str) ("<b>[str]</b>")
+#define FONT_ITALIC(str) ("<i>[str]</i>")
+#define FONT_BOLDANDITALIC(str) ("<b><i>[str]</b></i>")
+
+// size changes
+#define FONT_TINY(str) ("<font size='2'>[str]</font>")
+#define FONT_MEDIUM(str) ("<font size='5'>[str]</font>")
+#define FONT_LARGE(str) ("<font size='6'>[str]</font>")
+
+//colour changes
+#define FONT_BRIGHTRED(str) ("<font color='#DD0000'>[str]</font>")
+#define FONT_YELLOW(str) ("<font color='#F1D669'>[str]</font>")
+#define FONT_PURPLE(str) ("<font color='#800080'>[str]</font>")
+#define FONT_GREEN(str) ("<font color='#80B077'>[str]</font>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -139,8 +139,10 @@
 
 	if (!msg)
 		return
+	var/admin_msg = msg // let's dodge the formatting we're about to do to keep the admin log clean, there's probably a cleaner way to do it and if someone figures it out they should do it
+	msg = choose_text(msg)
 	to_chat(world, "[msg]")
-	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
+	log_admin("GlobalNarrate: [key_name(usr)] : [admin_msg]")
 	message_admins(span_adminnotice("[key_name_admin(usr)] Sent a global narrate"))
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -162,11 +164,14 @@
 	if( !msg )
 		return
 
+	var/admin_msg = msg
+	msg = choose_text(msg)
+
 	to_chat(M, msg)
-	log_admin("DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [msg]")
-	msg = span_adminnotice("<b> DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]):</b> [msg]<BR>")
-	message_admins(msg)
-	admin_ticket_log(M, msg)
+	log_admin("DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [admin_msg]")
+	admin_msg = span_adminnotice("<b> DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]):</b> [admin_msg]<BR>")
+	message_admins(admin_msg)
+	admin_ticket_log(M, admin_msg)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Direct Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_local_narrate(atom/A)
@@ -183,12 +188,51 @@
 	var/msg = input("Message:", text("Enter the text you wish to appear to everyone within view:")) as text|null
 	if (!msg)
 		return
+	var/admin_msg = msg
+	msg = choose_text(msg)
 	for(var/mob/M in view(range,A))
 		to_chat(M, msg)
 
-	log_admin("LocalNarrate: [key_name(usr)] at [AREACOORD(A)]: [msg]")
-	message_admins(span_adminnotice("<b> LocalNarrate: [key_name_admin(usr)] at [ADMIN_VERBOSEJMP(A)]:</b> [msg]<BR>"))
+	log_admin("LocalNarrate: [key_name(usr)] at [AREACOORD(A)]: [admin_msg]")
+	message_admins(span_adminnotice("<b> LocalNarrate: [key_name_admin(usr)] at [ADMIN_VERBOSEJMP(A)]:</b> [admin_msg]<BR>"))
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Local Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/choose_text(text)
+	if(!text)
+		return
+
+	var/fontsizes = list("Small", "Medium", "Large")
+	var/fontcolors = list("White", "Red", "Yellow", "Purple", "Green")
+	var/fontshapes = list("Normal", "Bold", "Italic", "Bold and Italic")
+	switch(input("Font Size", "How big do you want the text to be?") as anything in fontsizes)
+		if("Small")
+			text = FONT_TINY(text)
+		if("Medium")
+			text = FONT_MEDIUM(text)
+		if("Large")
+			text = FONT_LARGE(text)
+
+	switch(input("Font Color", "What color do you want the text to be?") as anything in fontcolors)
+		if("Red")
+			text = FONT_BRIGHTRED(text)
+		if("Yellow")
+			text = FONT_YELLOW(text)
+		if("Purple")
+			text = FONT_PURPLE(text)
+		if("Green")
+			text = FONT_GREEN(text)
+		// no mention for the "white" option because it's just to use the default text colour
+
+	switch(input("Font Shape", "What shape do you want the text to be?") as anything in fontshapes)
+		if("Bold")
+			text = FONT_BOLD(text)
+		if("Italic")
+			text = FONT_ITALIC(text)
+		if("Bold and Italic")
+			text = FONT_BOLDANDITALIC(text)
+		// no mention for "normal" because it's also just the default
+
+	return text
 
 /client/proc/cmd_admin_godmode(mob/M in GLOB.mob_list)
 	set category = "Admin"

--- a/html/changelogs/hocka-directnarratefix-i-pray.yml
+++ b/html/changelogs/hocka-directnarratefix-i-pray.yml
@@ -1,0 +1,6 @@
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - rscadd: "Direct Narrate, Global Narrate and Local Narrate now lets you choose the size, colour and shape of the text it outputs."

--- a/html/changelogs/hocka-directnarratefix-i-pray.yml
+++ b/html/changelogs/hocka-directnarratefix-i-pray.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Direct Narrate, Global Narrate and Local Narrate now lets you choose the size, colour and shape of the text it outputs."
+  - refactor: "Added a bunch of defines such as FONT_TINY(), FONT_BRIGHTRED() etc to serve as an alternative to spans, this was mostly to make the changes to narrate a bit more readable but it should be nice to take advantage of in the future, with far less arbitraty names than the span defines."

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -54,6 +54,7 @@
 #include "code\__DEFINES\exports.dm"
 #include "code\__DEFINES\fantasy_affixes.dm"
 #include "code\__DEFINES\flags.dm"
+#include "code\__DEFINES\font_changers.dm"
 #include "code\__DEFINES\food.dm"
 #include "code\__DEFINES\footsteps.dm"
 #include "code\__DEFINES\forensics.dm"


### PR DESCRIPTION
When using Local, Direct and Global Narrate verbs you will now be prompted to choose the size, colour and shape of your font (e.g medium, red, & italic). Hopefully this will be quite helpful for people running events since it should let you make your narrates stand out more instead of being a normal standard white (unless you want it to!) as well as being able to make the text bigger and smaller to account for different contexts.

I took the liberty of adding a few new defines while doing this - this was mostly to make the new code more readable, but I hope it'll be good for others to take advantage of in the future - especially because the names of the defines should be way less arbitraty than the span defines (e.g span_phobia() vs. FONT_BRIGHTRED() ). Hopefully the template is easy enough to follow if people want to add other colours/sizes later down the line.

Fixes #184 