### PR TITLE
Fixes merchant machines

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -65,26 +65,26 @@ SUBSYSTEM_DEF(shuttle)
 	var/datum/turf_reservation/preview_reservation
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
-	// ordernum = rand(1, 9000)
+	ordernum = rand(1, 9000)
 
-	// for(var/pack in subtypesof(/datum/supply_pack/rogue))
-	// 	var/datum/supply_pack/P = new pack()
-	// 	if(!P.contains)
-	// 		continue
-	// 	supply_packs[P.type] = P
-	// 	if(!(P.group in supply_cats))
-	// 		supply_cats += P.group
+	for(var/pack in subtypesof(/datum/supply_pack/rogue))
+		var/datum/supply_pack/P = new pack()
+		if(!P.contains)
+			continue
+		supply_packs[P.type] = P
+		if(!(P.group in supply_cats))
+			supply_cats += P.group
 
 	// initial_load()
 
 	// if(!arrivals)
-	// 	WARNING("No /obj/docking_port/mobile/arrivals placed on the map!")
+	//	WARNING("No /obj/docking_port/mobile/arrivals placed on the map!")
 	// if(!emergency)
 	// 	WARNING("No /obj/docking_port/mobile/emergency placed on the map!")
 	// if(!backup_shuttle)
-	// 	WARNING("No /obj/docking_port/mobile/emergency/backup placed on the map!")
+	//	WARNING("No /obj/docking_port/mobile/emergency/backup placed on the map!")
 	// if(!supply)
-	// 	WARNING("No /obj/docking_port/mobile/supply placed on the map!")
+	//	WARNING("No /obj/docking_port/mobile/supply placed on the map!")
 	return ..()
 
 /datum/controller/subsystem/shuttle/proc/initial_load()

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -65,7 +65,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/datum/turf_reservation/preview_reservation
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
-	ordernum = rand(1, 9000)
+	// ordernum = rand(1, 9000)
 
 	for(var/pack in subtypesof(/datum/supply_pack/rogue))
 		var/datum/supply_pack/P = new pack()

--- a/html/changelogs/hocka-merchantfix.yml
+++ b/html/changelogs/hocka-merchantfix.yml
@@ -1,0 +1,6 @@
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - bugfix: "Uncommented some of the shuttle code to allow merchant-type machines to work."


### PR DESCRIPTION
Uncomments some code in shuttle.dm to allow the supply packs to populate correctly, thus allow merchant machines (and the dragon hoard for bandits) to actually be used.

Fixes #263 