### PR TITLE
Prideful Heir Skill Tweak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -32,7 +32,7 @@
 
 /datum/advclass/heir/daring
 	name = "Prideful Heir"
-	tutorial = "You're a somebody, someone important. You were always able to harness the powers of the One Envy well, and have some semblance of control over a club, at least."
+	tutorial = "You're a somebody, someone important. You were always able to harness the powers of the One Envy well, and have some semblance of control over a sword, at least."
 	outfit = /datum/outfit/job/roguetown/heir/daring
 	category_tags = list(CTAG_HEIR)
 
@@ -48,10 +48,10 @@
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	backr = /obj/item/storage/backpack/rogue/satchel
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)

--- a/html/changelogs/furrycactus - shirleigh-skill-tweak.yml
+++ b/html/changelogs/furrycactus - shirleigh-skill-tweak.yml
@@ -1,0 +1,55 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Increases the Heir skill in Swords to Journeyman."
+  - qol: "Reduces the Heir skill in Maces to Apprentice."


### PR DESCRIPTION
  - qol: "Increases the Prideful Heir skill in Swords to Journeyman."
  - qol: "Reduces the Prideful Heir skill in Maces to Apprentice."

This is because Prideful Heirs already start with a steel sword, and all the fancy weapons in the Keep for the royals are swords too. And since a sword makes more sense as a weapon for the nobility.

Not sure why they got Journeyman with Maces instead when there weren't any available. 