### PR TITLE
Bronze Prosthetics Vices

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -17,6 +17,10 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Wood Arm (L)"=/datum/charflaw/limbloss/arm_l,
 	"Peg Leg (R)" = /datum/charflaw/limbloss/leg_r,
 	"Peg Leg (L)" = /datum/charflaw/limbloss/leg_l,
+	"Bronze Arm (R)"=/datum/charflaw/limbloss/arm_r_bronze,
+	"Bronze Arm (L)"=/datum/charflaw/limbloss/arm_l_bronze,
+	"Bronze Leg (R)" = /datum/charflaw/limbloss/leg_r_bronze,
+	"Bronze Leg (L)" = /datum/charflaw/limbloss/leg_l_bronze,
 	"Random or No Flaw"=/datum/charflaw/randflaw,
 	"No Flaw"=/datum/charflaw/eznoflaw
 	))

--- a/code/datums/character_flaw/limbloss.dm
+++ b/code/datums/character_flaw/limbloss.dm
@@ -56,3 +56,55 @@
 	var/mob/living/carbon/human/H = user
 	var/obj/item/bodypart/l_leg/prosthetic/wood/L = new()
 	L.replace_limb(H, TRUE)
+
+/datum/charflaw/limbloss/arm_r_bronze
+	name = "Bronze Arm (R)"
+	desc = "I lost my right arm long ago, but the bronze arm is a technological marvel!"
+	lost_zone = BODY_ZONE_R_ARM
+
+/datum/charflaw/limbloss/arm_r_bronze/on_mob_creation(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	var/obj/item/bodypart/r_arm/prosthetic/bronzeright/L = new()
+	L.replace_limb(H, TRUE)
+
+/datum/charflaw/limbloss/arm_l_bronze
+	name = "Bronze Arm (L)"
+	desc = "I lost my left arm long ago, but the bronze arm is a technological marvel!"
+	lost_zone = BODY_ZONE_L_ARM
+
+/datum/charflaw/limbloss/arm_l_bronze/on_mob_creation(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	var/obj/item/bodypart/l_arm/prosthetic/bronzeleft/L = new()
+	L.replace_limb(H, TRUE)
+
+/datum/charflaw/limbloss/leg_r_bronze
+	name = "Bronze Leg (R)"
+	desc = "I lost my right leg long ago, but the bronze leg is a technological marvel!"
+	lost_zone = BODY_ZONE_R_LEG
+
+/datum/charflaw/limbloss/leg_r_bronze/on_mob_creation(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	var/obj/item/bodypart/r_leg/prosthetic/bronze/L = new()
+	L.replace_limb(H, TRUE)
+
+/datum/charflaw/limbloss/leg_l_bronze
+	name = "Bronze Leg (L)"
+	desc = "I lost my left leg long ago, but the bronze leg is a technological marvel!"
+	lost_zone = BODY_ZONE_L_LEG
+
+/datum/charflaw/limbloss/leg_l_bronze/on_mob_creation(mob/user)
+	..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	var/obj/item/bodypart/l_leg/prosthetic/bronze/L = new()
+	L.replace_limb(H, TRUE)

--- a/html/changelogs/furrycactus - bronze_prosthetics_vice.yml
+++ b/html/changelogs/furrycactus - bronze_prosthetics_vice.yml
@@ -1,0 +1,54 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds vices for having bronze prosthetics, similar to the ones that grant wooden ones."


### PR DESCRIPTION
Adds four new vices for spawning with a bronze prosthetic limb, similar to the existing ones that allow you to spawn with wooden ones.