### PR TITLE
Garrison Armoury Tweaks

### DIFF
--- a/_maps/map_files/domotan/domotan.dmm
+++ b/_maps/map_files/domotan/domotan.dmm
@@ -16426,9 +16426,11 @@
 /area/rogue/indoors/town/church/chapel)
 "ojW" = (
 /obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
-/obj/item/clothing/suit/roguetown/armor/chainmail,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
 /obj/item/clothing/suit/roguetown/armor/chainmail,
 /turf/open/floor/rogue/cobble,
@@ -17462,8 +17464,30 @@
 	icon_state = "cobbleedge-sread"
 	},
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/shield/buckler,
-/obj/item/rogueweapon/shield/buckler,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special{
+	pixel_x = -4
+	},
+/obj/item/rogueweapon/huntingknife/idagger/steel/special{
+	pixel_x = -4
+	},
+/obj/item/rogueweapon/huntingknife/idagger{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/huntingknife/idagger{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/huntingknife/idagger{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/huntingknife/idagger{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/huntingknife/idagger{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/huntingknife/idagger{
+	pixel_x = 8
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oYM" = (
@@ -19731,6 +19755,8 @@
 /obj/item/rogueweapon/shield/wood,
 /obj/item/rogueweapon/shield/wood,
 /obj/item/rogueweapon/shield/wood,
+/obj/item/rogueweapon/shield/buckler,
+/obj/item/rogueweapon/shield/buckler,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "raB" = (
@@ -22608,9 +22634,25 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/short,
 /obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
-/obj/item/rogueweapon/sword/short,
 /obj/machinery/light/rogue/torchholder/l,
+/obj/item/rogueweapon/sword/iron/short{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/sword/iron/short{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/sword/iron/short{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/sword/iron/short{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/sword/iron/short{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/sword/iron/short{
+	pixel_x = 8
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "tBj" = (
@@ -23829,10 +23871,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/rogueweapon/sword/iron{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "uFD" = (
@@ -24386,6 +24424,12 @@
 /obj/item/rogueweapon/sword/iron/messer{
 	pixel_x = -3;
 	pixel_y = 2
+	},
+/obj/item/rogueweapon/huntingknife/idagger/steel/parrying{
+	pixel_x = 8
+	},
+/obj/item/rogueweapon/huntingknife/idagger/steel/parrying{
+	pixel_x = 8
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)

--- a/html/changelogs/furrycactus - garrison_armoury_tweaks.yml
+++ b/html/changelogs/furrycactus - garrison_armoury_tweaks.yml
@@ -1,0 +1,54 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   maptweak
+#     - (map updates/tweaks)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   refactor
+#     - (refactors code)
+#   admin
+#     - (makes changes to administrator tools)
+#################################
+
+# Your name.
+author: "Furrycactus"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Tweaked the gear in the Garrison armoury."


### PR DESCRIPTION
Didn't notice the Garrison when making those iron/steel adjustments.

- More iron gear has been added to the Garrison.
- Amount of steel gear in there is largely kept the same in most cases, but now there's extra iron to hand out to peasants if they need to be geared up for some kind of crisis.
- Added daggers to one of the weapon racks, since there's a Warden subclass that has knife-fighting skills now, so they can replace their knives if they lose or break them.