### PR TITLE
Fixes Archer's Apprentice & Warden's Apprentice

### DIFF
--- a/html/changelogs/hocka-axeman-archer-bugfix.yml
+++ b/html/changelogs/hocka-axeman-archer-bugfix.yml
@@ -1,0 +1,6 @@
+author: "Hocka"
+
+delete-after: True
+
+changes:
+  - bugfix: "Archer's Apprentice and Warden's Apprentice now get their appropriate skill modifiers."

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -130,7 +130,7 @@
 	custom_text = "Increases axe skill by 1, minimum apprentice. Increases tracking by 1, minimum apprentice. Capped at journeyman."
 	added_stashed_items = list("Iron Axe" = /datum/supply_pack/rogue/weapons/axe,
 								)
-/datum/virtue/combat/archer/apply_to_human(mob/living/carbon/human/recipient)
+/datum/virtue/combat/axeman/apply_to_human(mob/living/carbon/human/recipient)
 	if(recipient.mind?.get_skill_level(/datum/skill/combat/axes) < SKILL_LEVEL_APPRENTICE)
 		recipient.mind?.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_APPRENTICE, silent = TRUE)
 	else


### PR DESCRIPTION
The Warden's Apprentice proc for applying skills was typo'd as the one for Archer's Apprentice, resulting in Warden's Apprentice getting zero skill modifiers and Archer's Apprentice getting irrelevant ones. This PR corrects the typo.